### PR TITLE
add: std::ostream operator<< for Ok and Err

### DIFF
--- a/include/Result.hpp
+++ b/include/Result.hpp
@@ -120,6 +120,8 @@ class[[nodiscard]] Ok
   friend struct result::err_trait_injector;
   template <class, class>
   friend struct result::ok_err_trait_injector;
+  template <class, class>
+  friend struct result::printer_friend_injector;
   template <class... Requiers>
   using where = std::enable_if_t<std::conjunction_v<Requiers...>, std::nullptr_t>;
 
@@ -323,6 +325,7 @@ public:
   {
     return false;
   }
+
 };
 
 /*!
@@ -343,7 +346,9 @@ class[[nodiscard]] Err
           std::conjunction_v<std::is_copy_constructible<E>, std::is_copy_assignable<E>>,
           std::is_move_constructible_v<E>,
           std::conjunction_v<std::is_move_constructible<E>, std::is_move_assignable<E>>,
-          Err<E>>
+          Err<E>>,
+      public result::impl<Err<E>>
+
 {
   //! @cond
   template <class>
@@ -358,6 +363,8 @@ class[[nodiscard]] Err
   friend struct result::err_trait_injector;
   template <class, class>
   friend struct result::ok_err_trait_injector;
+  template <class, class>
+  friend struct result::printer_friend_injector;
   template <class... Requiers>
   using where = std::enable_if_t<std::conjunction_v<Requiers...>, std::nullptr_t>;
 

--- a/include/result/result_impl.hpp
+++ b/include/result/result_impl.hpp
@@ -24,6 +24,38 @@ struct ok_err_trait_injector
 {
 };
 
+template <class, class = std::nullptr_t> 
+struct printer_friend_injector {};
+
+template <class T>
+struct printer_friend_injector<Ok<T>,
+                               trait::where<
+                                   trait::formattable<T>>>
+{
+  std::ostream& print(std::ostream &os) const
+  {
+    return os << "Ok(" << static_cast<const Ok<T> *>(this)->x << ")";
+  }
+  friend std::ostream &operator<<(std::ostream& os, const Ok<T> &ok) {
+    return ok.print(os);
+  }
+};
+
+template <class T>
+struct printer_friend_injector<Err<T>,
+                               trait::where<
+                                   trait::formattable<T>>>
+{
+  std::ostream& print(std::ostream &os) const
+  {
+    return os << "Err(" << static_cast<const Err<T> *>(this)->x << ")";
+  }
+  friend std::ostream &operator<<(std::ostream &os, const Err<T> &err)
+  {
+    return err.print(os);
+  }
+};
+
 // copy-move injector
 template <class T, class E>
 struct ok_trait_injector<Result<T, E>,
@@ -339,7 +371,8 @@ struct impl
     : unwrap_or_default_injector<T>,
       ok_trait_injector<T>,
       err_trait_injector<T>,
-      ok_err_trait_injector<T>
+      ok_err_trait_injector<T>,
+      printer_friend_injector<T>
 {
 };
 

--- a/test/Result_Test.cpp
+++ b/test/Result_Test.cpp
@@ -372,6 +372,18 @@ int main(){
   res = Ok(1);
   res = Err(2);
 }
+{
+  using namespace std::literals;
+  std::stringstream ss;
+  ss << Ok(1);
+  assert_eq(ss.str(), "Ok(1)"s);
+}
+{
+  using namespace std::literals;
+  std::stringstream ss;
+  ss << Err(1);
+  assert_eq(ss.str(), "Err(1)"s);
+}
 
 std::cout << "\nall green !" << std::endl;
 


### PR DESCRIPTION
Add injector for `Ok<T>` and `Err<T>`.
`Ok<T>` and `Err<T>` are printable with operator << if and only if T is printable.