### PR TITLE
Fix `operator>>` of `maybe` for Boost.Optional

### DIFF
--- a/include/mitama/maybe/maybe.hpp
+++ b/include/mitama/maybe/maybe.hpp
@@ -416,7 +416,7 @@ class maybe
                 return maybe<typename mitamagic::element_type<std::decay_t<result_type>>::type>{std::invoke(std::forward<F>(f), storage_->deref())};
             }
             else {
-                return maybe<typename mitamagic::element_type<std::decay_t<result_type>>::type>{std::nullopt};
+                return maybe<typename mitamagic::element_type<std::decay_t<result_type>>::type>{boost::none};
             }
         }
         else {


### PR DESCRIPTION
Replaced `std::nullopt` with `boost::none`. [Fix #14]