### PR TITLE
Remove redundant `boost::none` at construction

### DIFF
--- a/include/mitama/maybe/maybe.hpp
+++ b/include/mitama/maybe/maybe.hpp
@@ -424,7 +424,7 @@ class maybe
                 return maybe<result_type>{boost::optional<result_type>(std::invoke(std::forward<F>(f), storage_->deref()))};
             }
             else {
-                return maybe<result_type>{boost::optional<result_type>{boost::none}};
+                return maybe<result_type>{boost::optional<result_type>{}};
             }
         }
     }


### PR DESCRIPTION
Fix #16