### PR TITLE
Improve CMakeLists.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,10 @@ jobs:
       - run: apt upgrade -y && apt update -y && apt install -y git
       - run: git submodule update --init --recursive
       - run: |
-          mkdir -p build && cd build && cmake .. && cmake --build .
-          find -type f -name "*-tests" | bash
+          mkdir -p build && cd build
+          cmake .. -DBUILD_TESTING=ON
+          make
+          make test
 
 workflows:
   build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,36 +1,45 @@
-cmake_minimum_required(VERSION 3.1)
-enable_language(CXX)
-set(CMAKE_CXX_STANDARD 17) # C++17...
-set(CMAKE_CXX_STANDARD_REQUIRED ON) #...is required...
-set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
-find_package(Threads REQUIRED)
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic-errors -ftemplate-backtrace-limit=0")
-# set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -pedantic-errors")
-
+cmake_minimum_required(VERSION 3.8)
 ## Set our project name
-project(mitama-cpp-result)
-
-# Find Boost
-# Find Boost
-find_package(Boost 1.67.0 REQUIRED
-  COMPONENTS
-  stacktrace_addr2line
+project(mitama-cpp-result
+  VERSION 9.2.1
+  LANGUAGES CXX
 )
 
-include_directories(
-  PUBLIC ${Boost_INCLUDE_DIRS}
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/Catch2/single_include
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mitama-utest-utilities/include
-  )
+include(GNUInstallDirs)
+set(CMAKE_VERBOSE_MAKEFILE ON)
 
-add_executable(result-tests test/Result_Test.cpp)
-add_executable(maybe-tests test/Maybe_Test.cpp)
+message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
+target_include_directories(${PROJECT_NAME} INTERFACE
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 
-target_link_libraries(result-tests ${Boost_LIBRARIES} dl)
-target_link_libraries(maybe-tests ${Boost_LIBRARIES} dl)
+set(CONFIG_VERSION_FILE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake)
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  ${CONFIG_VERSION_FILE} COMPATIBILITY AnyNewerVersion
+)
 
-add_test(result-tests "${EXECUTABLE_OUTPUT_PATH}/result-tests")
-add_test(maybe-tests "${EXECUTABLE_OUTPUT_PATH}/maybe-tests")
-enable_testing()
+install(DIRECTORY include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING PATTERN "*.hpp"
+)
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}-config
+)
+install(EXPORT ${PROJECT_NAME}-config
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
+  NAMESPACE ${PROJECT_NAME}::
+)
+install(FILES ${CONFIG_VERSION_FILE}
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
+)
+
+option(BUILD_TESTING "Do not build tests by default" OFF)
+include(CTest)
+if(BUILD_TESTING AND ${CMAKE_SOURCE_DIR} STREQUAL ${PROJECT_SOURCE_DIR})
+  add_subdirectory(test)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,44 @@
+find_package(Threads REQUIRED)
+set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
+
+# Find Boost
+find_package(Boost 1.67.0 REQUIRED
+  COMPONENTS
+  stacktrace_addr2line
+)
+
+message($CMAKE)
+
+add_executable(result-tests Result_Test.cpp)
+add_executable(maybe-tests Maybe_Test.cpp)
+
+target_compile_features(result-tests PRIVATE cxx_std_17)
+target_compile_features(maybe-tests PRIVATE cxx_std_17)
+
+target_compile_options(result-tests PRIVATE -Wall -Wextra -pedantic-errors -ftemplate-backtrace-limit=0)
+target_compile_options(maybe-tests PRIVATE -Wall -Wextra -pedantic-errors -ftemplate-backtrace-limit=0)
+# -Wall -Wextra -Werror -pedantic-errors
+
+if(APPLE)
+  target_compile_definitions(result-tests PRIVATE _GNU_SOURCE)
+endif()
+
+target_include_directories(result-tests
+  PRIVATE ${Boost_INCLUDE_DIRS}
+  PRIVATE ${CMAKE_SOURCE_DIR}/include
+  PRIVATE ${CMAKE_SOURCE_DIR}/Catch2/single_include
+  PRIVATE ${CMAKE_SOURCE_DIR}/mitama-utest-utilities/include
+)
+target_include_directories(maybe-tests
+  PRIVATE ${Boost_INCLUDE_DIRS}
+  PRIVATE ${CMAKE_SOURCE_DIR}/include
+  PRIVATE ${CMAKE_SOURCE_DIR}/Catch2/single_include
+  PRIVATE ${CMAKE_SOURCE_DIR}/mitama-utest-utilities/include
+)
+
+target_link_libraries(result-tests ${Boost_LIBRARIES} dl)
+target_link_libraries(maybe-tests ${Boost_LIBRARIES} dl)
+
+add_test(NAME result-tests COMMAND result-tests WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+add_test(NAME maybe-tests COMMAND maybe-tests WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+enable_testing()


### PR DESCRIPTION
This PR includes:
* Improve CMakeLists.txt to be able to install include dirs
* Disable testing by default
* Fix the problem that building `Result_Test.cpp` fails on macOS (resolves #62)
* Some improvements of CMake command usage

## Installation
```bash
$ mkdir build
$ cmake ..
$ make install
```

## Testing
```bash
$ mkdir build
$ cmake .. -DBUILD_TESTING=ON
$ make
$ make test
```