### PR TITLE
Add a TRY macro like the Rust's `?` operator

### DIFF
--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -1628,7 +1628,7 @@ public:
 // MSVC does not implement compound statements (ref: https://stackoverflow.com/q/5291532)
 #if defined(__GNUC__) || defined(__clang__)
 #  define MITAMA_CPP_RESULT_TRY_MAY_NOT_PANIC true
-#  define TRY( result )                                                \
+#  define MITAMA_TRY( result )                                         \
     ({                                                                 \
         if (result.is_err()) {                                         \
             using Err = mitama::failure_t<decltype(result)::err_type>; \
@@ -1639,7 +1639,7 @@ public:
     })
 #else
 #  define MITAMA_CPP_RESULT_TRY_MAY_NOT_PANIC false
-#  define TRY( result ) result.unwrap()
+#  define MITAMA_TRY( result ) result.unwrap()
 #endif
 
 #endif


### PR DESCRIPTION
Usage:
```cpp
mitama::result<int, std::string>
func1(int a)
noexcept
{
  if ( first check )
    return mitama::failure("first check failed"); // early return
  if ( second check )
    return mitama::failure("second check failed"); // early return
  if ( third check )
    return mitama::failure("third check failed"); // early return
  // function body...
  return mitama::success(42);
}

mitama::result<int, std::string>
func2(int a)
noexcept(MITAMA_CPP_RESULT_TRY_MAY_NOT_PANIC)
{
  int value = TRY(func1(a));
  return mitama::success(value);
}

// ...

int value = TRY(func2(42));
```

Since [MSVC does not implement compound statements](https://stackoverflow.com/q/5291532), the processing of the TRY macro changes between MSVC and others; therefore, there is a `MITAMA_CPP_RESULT_TRY_MAY_NOT_PANIC` macro to detect whether the TRY macro will panic or not.