### PR TITLE
Avoid double evaluation in the MITAMA_TRY macro

### DIFF
--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -1776,8 +1776,9 @@ public:
 // MSVC does not implement compound statements (ref: https://stackoverflow.com/q/5291532)
 #if defined(__GNUC__) || defined(__clang__)
 #  define MITAMA_CPP_RESULT_TRY_MAY_NOT_PANIC true
-#  define MITAMA_TRY( result )                                         \
+#  define MITAMA_TRY( RESULT )                                         \
     ({                                                                 \
+        const auto result = RESULT;                                    \
         if (result.is_err()) {                                         \
             using Err = mitama::failure_t<decltype(result)::err_type>; \
             return std::get<Err>(result.into_storage());               \
@@ -1787,7 +1788,7 @@ public:
     })
 #else
 #  define MITAMA_CPP_RESULT_TRY_MAY_NOT_PANIC false
-#  define MITAMA_TRY( result ) result.unwrap()
+#  define MITAMA_TRY( RESULT ) RESULT.unwrap()
 #endif
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,8 +17,11 @@ message($CMAKE)
 foreach(TEST_NAME ${TEST_NAMES})
   add_executable(${TEST_NAME} ${TEST_NAME}.cpp)
   target_compile_features(${TEST_NAME} PRIVATE cxx_std_17)
-  target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -pedantic-errors -ftemplate-backtrace-limit=0)
-  # -Wall -Wextra -Werror -pedantic-errors
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -ftemplate-backtrace-limit=0)
+  else()
+    target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -pedantic-errors -ftemplate-backtrace-limit=0)
+  endif()
 
   if(APPLE)
     target_compile_definitions(${TEST_NAME} PRIVATE _GNU_SOURCE)

--- a/test/result_tests.cpp
+++ b/test/result_tests.cpp
@@ -1285,3 +1285,24 @@ TEST_CASE("map & map_err with void", "[result][map][map_err][void]"){
     REQUIRE(y.is_ok() == true);
     REQUIRE(val == 6);
 }
+
+TEST_CASE("MITAMA_TRY", "[result][mitama_try]"){
+    auto func =
+        []() -> result<u32, str> {
+            result<u32, str> a = success(1);
+            u32 b = 2, c = 3;
+            u32 d = MITAMA_TRY(
+                [&a, &b, &c]() -> ::result<u32, str> {
+                    return a.map(
+                        [&b, &c](u32 x) -> u32 { return x + b + c; }
+                    );
+                }()
+            );
+            return success(d);
+        };
+
+    result<u32, str> x = func();
+    REQUIRE(MITAMA_CPP_RESULT_TRY_MAY_NOT_PANIC == true);
+    REQUIRE(x.is_ok() == true);
+    REQUIRE(x.unwrap() == 6);
+}

--- a/test/result_tests.cpp
+++ b/test/result_tests.cpp
@@ -1306,3 +1306,12 @@ TEST_CASE("MITAMA_TRY", "[result][mitama_try]"){
     REQUIRE(x.is_ok() == true);
     REQUIRE(x.unwrap() == 6);
 }
+
+TEST_CASE("MITAMA_TRY2", "[result][mitama_try]"){
+  (void)[]{
+    auto res = mut_result<std::unique_ptr<u32>>{mitama::in_place_ok, new auto(42u)};
+
+    auto&& ret = MITAMA_TRY(std::move(res));
+    return mitama::failure();
+  }();
+}


### PR DESCRIPTION
When passing a function call like the below,
```cpp
MITAMA_TRY(func(42));
```

this will be expanded that will cause double evaluation:
```cpp
({
    if (func(42).is_err()) {
        using Err = mitama::failure_t<decltype(func(42))::err_type>;
        return std::get<Err>(func(42).into_storage());
    }
    using Ok = mitama::success_t<decltype(func(42))::ok_type>;
    std::get<Ok>(func(42).into_storage()).get();
})
```

So, I fixed the MITAMA_TRY macro to expand like this:
```cpp
({
    const auto result = func(42);
    if (result.is_err()) {
        using Err = mitama::failure_t<decltype(result)::err_type>;
        return std::get<Err>(result.into_storage());
    }
    using Ok = mitama::success_t<decltype(result)::ok_type>;
    std::get<Ok>(result.into_storage()).get();
})
```