### PR TITLE
Fix an error with an extraneous closing brace

### DIFF
--- a/include/mitama/thiserror/thiserror.hpp
+++ b/include/mitama/thiserror/thiserror.hpp
@@ -11,7 +11,7 @@
 #include <utility>
 
 #if __cplusplus >= 202002L
-namespace mitama::thiserror::v1 {
+namespace mitama::thiserror { namespace v1 {
 #else
 #include <boost/metaparse/string.hpp>
 #define MITAMA_ERROR(MSG) BOOST_METAPARSE_STRING(MSG)


### PR DESCRIPTION
The following closing braces did not correspond to the declaration of namespaces when C++20 is enabled.

1. C++20 is enabled:
https://github.com/LoliGothick/mitama-cpp-result/blob/fddf59f97930cc16a159e8b10b03198ea27d602a/include/mitama/thiserror/thiserror.hpp#L14

2. Lower version than C++20:
https://github.com/LoliGothick/mitama-cpp-result/blob/fddf59f97930cc16a159e8b10b03198ea27d602a/include/mitama/thiserror/thiserror.hpp#L18

https://github.com/LoliGothick/mitama-cpp-result/blob/fddf59f97930cc16a159e8b10b03198ea27d602a/include/mitama/thiserror/thiserror.hpp#L56