### PR TITLE
Add an option to disable `thiserror::v1`

### DIFF
--- a/include/mitama/thiserror/thiserror.hpp
+++ b/include/mitama/thiserror/thiserror.hpp
@@ -11,6 +11,16 @@
 #include <utility>
 
 #if __cplusplus >= 202002L
+#  ifndef MITAMA_THISERROR_ENABLE_V1
+// Disable v1 by default on C++20
+#    define MITAMA_THISERROR_ENABLE_V1 false
+#  endif
+#else
+// Enforce enabling v1 before C++20
+#  define MITAMA_THISERROR_ENABLE_V1 true
+#endif
+
+#if __cplusplus >= 202002L
 namespace mitama::thiserror { namespace v1 {
 #else
 #include <boost/metaparse/string.hpp>
@@ -18,6 +28,7 @@ namespace mitama::thiserror { namespace v1 {
 namespace mitama::thiserror { inline namespace v1 {
 #endif
 
+#if MITAMA_THISERROR_ENABLE_V1
   template <class String, class ...Sources>
   struct error;
 
@@ -53,7 +64,10 @@ namespace mitama::thiserror { inline namespace v1 {
       return ss.str();
     }
   };
+#endif
+
 }}
+
 #if __cplusplus >= 202002L
 namespace mitama::thiserror:: inline v2 {
   template<unsigned N>


### PR DESCRIPTION
This PR brings an option to disable `thiserror::v1` when using C++20.
The `v1` is now disabled by default on C++20 because I think most users do not want to use an extra dependency (`Boost.Metaparse`). When we want to keep `v1`, we can enable it by defining `MITAMA_THISERROR_ENABLE_V1` like `#define MITAMA_THISERROR_ENABLE_V1 true`.
