### PR TITLE
Let `thiserror::v2::error` inherit `anyhow::error`

### DIFF
--- a/include/mitama/thiserror/thiserror.hpp
+++ b/include/mitama/thiserror/thiserror.hpp
@@ -77,7 +77,7 @@ namespace mitama::thiserror:: inline v2 {
 
   // any string literal in non-template argument
   template<fixed_string Fmt, class ...Sources>
-  struct error {
+  struct error final : anyhow::error {
     static constexpr char const* fmt = Fmt;
     std::tuple<Sources...> sources;
 


### PR DESCRIPTION
This inheritance is required by the constraint in the following function:

https://github.com/LoliGothick/mitama-cpp-result/blob/5ce08203c254d24d6644daff7eb95f987a486442/include/mitama/anyhow/error.hpp#L92-L96