### PR TITLE
Avoid redefinition of 'fmt' when both <format> & <fmt> exist

### DIFF
--- a/include/mitama/mitamagic/format.hpp
+++ b/include/mitama/mitamagic/format.hpp
@@ -1,6 +1,6 @@
 #ifndef MITAMA_CPP_RESULT_FORMAT_HPP
 #define MITAMA_CPP_RESULT_FORMAT_HPP
-#if __has_include(<format>)
+#if __has_include(<format>) && !__has_include(<fmt/format.h>)
 #include <format>
 namespace fmt = std;
 #else


### PR DESCRIPTION
I'd recommend defining a new namespace for them such as `mitama_fmt`.