### PR TITLE
Deploy docs when pushed to master

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,7 @@ name: Deploy Document
 
 on:
   push:
-    tags: [ v* ]
+    branches: [ master ]
 
 jobs:
   deploy_docs:


### PR DESCRIPTION
I think it would be much better to deploy docs when the master branch is updated. (because when deploying docs failed, we have to bump a redundant release)