### PR TITLE
add constexpr

### DIFF
--- a/include/mitama/boolinators.hpp
+++ b/include/mitama/boolinators.hpp
@@ -37,7 +37,7 @@ and_maybe(bool b, const maybe<T>& may)
 
 template <class F>
   requires std::is_invocable_v<F&&>
-           && is_maybe<std::invoke_result_t<F&&>>::value
+               && is_maybe<std::invoke_result_t<F&&>>::value
 inline constexpr auto
 and_maybe_from(bool b, F&& may) -> std::invoke_result_t<F&&>
 {

--- a/include/mitama/boolinators.hpp
+++ b/include/mitama/boolinators.hpp
@@ -37,7 +37,7 @@ and_maybe(bool b, const maybe<T>& may)
 
 template <class F>
   requires std::is_invocable_v<F&&>
-               && is_maybe<std::invoke_result_t<F&&>>::value
+           && is_maybe<std::invoke_result_t<F&&>>::value
 inline constexpr auto
 and_maybe_from(bool b, F&& may) -> std::invoke_result_t<F&&>
 {

--- a/include/mitama/boolinators.hpp
+++ b/include/mitama/boolinators.hpp
@@ -8,28 +8,28 @@
 
 namespace mitama
 {
-inline maybe<std::monostate>
+inline constexpr maybe<std::monostate>
 as_maybe(bool b)
 {
   return b ? maybe<std::monostate>{ std::in_place } : nothing;
 }
 
 template <class T>
-inline maybe<T>
+inline constexpr maybe<T>
 as_just(bool b, T&& some)
 {
   return b ? maybe<T>{ std::forward<T>(some) } : nothing;
 }
 
 template <class F>
-inline maybe<std::invoke_result_t<F&&>>
+inline constexpr maybe<std::invoke_result_t<F&&>>
 as_just_from(bool b, F&& some)
 {
   return b ? maybe{ std::invoke(std::forward<F>(some)) } : nothing;
 }
 
 template <class T>
-inline maybe<T>
+inline constexpr maybe<T>
 and_maybe(bool b, const maybe<T>& may)
 {
   return b ? may : nothing;
@@ -38,7 +38,7 @@ and_maybe(bool b, const maybe<T>& may)
 template <class F>
   requires std::is_invocable_v<F&&>
            && is_maybe<std::invoke_result_t<F&&>>::value
-inline auto
+inline constexpr auto
 and_maybe_from(bool b, F&& may) -> std::invoke_result_t<F&&>
 {
   return b ? std::invoke(std::forward<F>(may)) : nothing;

--- a/include/mitama/boolinators.hpp
+++ b/include/mitama/boolinators.hpp
@@ -45,14 +45,14 @@ and_maybe_from(bool b, F&& may) -> std::invoke_result_t<F&&>
 }
 
 template <class T>
-inline result<T>
+inline constexpr result<T>
 as_ok(bool b, T&& ok)
 {
   return b ? result<T>(success(std::forward<T>(ok))) : failure();
 }
 
 template <class T, class E>
-inline result<T, E>
+inline constexpr result<T, E>
 as_result(bool b, T&& ok, E&& err)
 {
   return b ? result<T, E>{ success(std::forward<T>(ok)) }
@@ -60,7 +60,7 @@ as_result(bool b, T&& ok, E&& err)
 }
 
 template <class F, class G>
-inline result<std::invoke_result_t<F>, std::invoke_result_t<G&&>>
+inline constexpr result<std::invoke_result_t<F>, std::invoke_result_t<G&&>>
 as_result_from(bool b, F&& ok, G&& err)
 {
   using result_type =
@@ -70,7 +70,7 @@ as_result_from(bool b, F&& ok, G&& err)
 }
 
 template <class E>
-inline result<void, E>
+inline constexpr result<void, E>
 ok_or(bool b, E&& err)
 {
   return b ? result<void, E>{ success() }
@@ -78,7 +78,7 @@ ok_or(bool b, E&& err)
 }
 
 template <class G>
-inline result<void, std::invoke_result_t<G&&>>
+inline constexpr result<void, std::invoke_result_t<G&&>>
 ok_or_else(bool b, G&& err)
 {
   using result_type = result<void, std::invoke_result_t<G>>;

--- a/include/mitama/maybe/factory/just_nothing.hpp
+++ b/include/mitama/maybe/factory/just_nothing.hpp
@@ -117,7 +117,8 @@ public:
   template <class U>
     requires not_self<std::decay_t<U>>::value
              && std::is_constructible_v<T, U> && (!std::is_convertible_v<U, T>)
-  explicit constexpr just_t(U&& u
+  explicit constexpr just_t(
+      U&& u
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::forward<U>(u))
   {
@@ -126,7 +127,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, const U&>
             && std::is_convertible_v<const U&, T>
-  constexpr just_t(const just_t<U>& t
+  constexpr just_t(
+      const just_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(t.get())
   {
@@ -135,7 +137,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, const U&>
             && (!std::is_convertible_v<const U&, T>)
-  explicit constexpr just_t(const just_t<U>& t
+  explicit constexpr just_t(
+      const just_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(t.get())
   {
@@ -144,8 +147,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>)
             && std::is_constructible_v<T, U&&> && std::is_convertible_v<U&&, T>
-  constexpr just_t(just_t<U>&& t
-  ) noexcept(std::is_nothrow_constructible_v<T, U>)
+  constexpr just_t(just_t<U>&& t) noexcept(std::is_nothrow_constructible_v<T, U>
+  )
       : x(std::move(t.get()))
   {
   }
@@ -153,7 +156,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, U&&>
             && (!std::is_convertible_v<U &&, T>)
-  explicit constexpr just_t(just_t<U>&& t
+  explicit constexpr just_t(
+      just_t<U>&& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::move(t.get()))
   {
@@ -187,14 +191,14 @@ public:
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
-  friend bool operator==(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator==(const maybe<U>& lhs, const just_t& rhs)
   {
     return lhs && (lhs.unwrap() == rhs.get());
   }
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
-  friend bool operator==(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator==(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs && (lhs.get() == rhs.unwrap());
   }
@@ -218,14 +222,14 @@ public:
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
-  friend bool operator!=(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator!=(const maybe<U>& lhs, const just_t& rhs)
   {
     return lhs.is_nothing() || !(lhs.unwrap() == rhs.get());
   }
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
-  friend bool operator!=(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator!=(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs.is_nothing() || !(lhs.get() == rhs.unwrap());
   }
@@ -249,14 +253,14 @@ public:
 
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
-  friend bool operator<(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator<(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs ? lhs.get() < rhs.unwrap() : false;
   }
 
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
-  friend bool operator<(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator<(const maybe<U>& lhs, const just_t& rhs)
   {
     return lhs ? lhs.unwrap() < rhs.get() : true;
   }
@@ -282,7 +286,7 @@ public:
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
              && meta::is_comparable_with<T, U>::value
-  friend bool operator<=(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator<=(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs ? (lhs.get() < rhs.unwrap() || lhs.get() == rhs.unwrap())
                : false;
@@ -291,7 +295,7 @@ public:
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
              && meta::is_comparable_with<T, U>::value
-  friend bool operator<=(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator<=(const maybe<U>& lhs, const just_t& rhs)
   {
     return lhs ? (lhs.unwrap() < rhs.get() || lhs.unwrap() == rhs.get()) : true;
   }
@@ -308,21 +312,21 @@ public:
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
-  bool operator>(const just_t<U>& rhs) const
+  constexpr bool operator>(const just_t<U>& rhs) const
   {
     return rhs < *this;
   }
 
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
-  friend bool operator>(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator>(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs < lhs;
   }
 
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
-  friend bool operator>(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator>(const maybe<U>& lhs, const just_t& rhs)
   {
     return rhs < lhs;
   }
@@ -340,7 +344,7 @@ public:
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
              && meta::is_comparable_with<T, U>::value
-  bool operator>=(const just_t<U>& rhs) const
+  constexpr bool operator>=(const just_t<U>& rhs) const
   {
     return rhs <= *this;
   }
@@ -348,7 +352,7 @@ public:
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
              && meta::is_comparable_with<T, U>::value
-  friend bool operator>=(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator>=(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs <= lhs;
   }
@@ -356,20 +360,20 @@ public:
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
              && meta::is_comparable_with<T, U>::value
-  friend bool operator>=(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator>=(const maybe<U>& lhs, const just_t& rhs)
   {
     return rhs <= lhs;
   }
 
-  T& get() &
+  constexpr T& get() &
   {
     return x;
   }
-  const T& get() const&
+  constexpr const T& get() const&
   {
     return x;
   }
-  T&& get() &&
+  constexpr T&& get() &&
   {
     return std::move(x);
   }
@@ -427,14 +431,14 @@ public:
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
-  friend bool operator==(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator==(const maybe<U>& lhs, const just_t& rhs)
   {
     return lhs && (lhs.unwrap() == rhs.get());
   }
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
-  friend bool operator==(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator==(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs && (lhs.get() == rhs.unwrap());
   }
@@ -458,14 +462,14 @@ public:
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
-  friend bool operator!=(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator!=(const maybe<U>& lhs, const just_t& rhs)
   {
     return lhs.is_nothing() || !(lhs.unwrap() == rhs.get());
   }
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
-  friend bool operator!=(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator!=(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs.is_nothing() || !(lhs.get() == rhs.unwrap());
   }
@@ -489,14 +493,14 @@ public:
 
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
-  friend bool operator<(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator<(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs ? lhs.get() < rhs.unwrap() : false;
   }
 
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
-  friend bool operator<(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator<(const maybe<U>& lhs, const just_t& rhs)
   {
     return lhs ? lhs.unwrap() < rhs.get() : true;
   }
@@ -522,7 +526,7 @@ public:
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
              && meta::is_comparable_with<T, U>::value
-  friend bool operator<=(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator<=(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs ? (lhs.get() < rhs.unwrap() || lhs.get() == rhs.unwrap())
                : false;
@@ -531,7 +535,7 @@ public:
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
              && meta::is_comparable_with<T, U>::value
-  friend bool operator<=(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator<=(const maybe<U>& lhs, const just_t& rhs)
   {
     return lhs ? (lhs.unwrap() < rhs.get() || lhs.unwrap() == rhs.get()) : true;
   }
@@ -548,21 +552,21 @@ public:
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
-  bool operator>(const just_t<U>& rhs) const
+  constexpr bool operator>(const just_t<U>& rhs) const
   {
     return rhs < *this;
   }
 
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
-  friend bool operator>(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator>(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs < lhs;
   }
 
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
-  friend bool operator>(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator>(const maybe<U>& lhs, const just_t& rhs)
   {
     return rhs < lhs;
   }
@@ -580,7 +584,7 @@ public:
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
              && meta::is_comparable_with<T, U>::value
-  bool operator>=(const just_t<U>& rhs) const
+  constexpr bool operator>=(const just_t<U>& rhs) const
   {
     return rhs <= *this;
   }
@@ -588,7 +592,7 @@ public:
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
              && meta::is_comparable_with<T, U>::value
-  friend bool operator>=(const just_t& lhs, const maybe<U>& rhs)
+  friend constexpr bool operator>=(const just_t& lhs, const maybe<U>& rhs)
   {
     return rhs <= lhs;
   }
@@ -596,20 +600,20 @@ public:
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
              && meta::is_comparable_with<T, U>::value
-  friend bool operator>=(const maybe<U>& lhs, const just_t& rhs)
+  friend constexpr bool operator>=(const maybe<U>& lhs, const just_t& rhs)
   {
     return rhs <= lhs;
   }
 
-  T& get() &
+  constexpr T& get() &
   {
     return x.get();
   }
-  const T& get() const&
+  constexpr const T& get() const&
   {
     return x.get();
   }
-  T& get() &&
+  constexpr T& get() &&
   {
     return x.get();
   }
@@ -623,7 +627,7 @@ operator<<(std::ostream& os, const just_t<T>& j)
 }
 
 template <class Target = void, class... Types>
-auto
+constexpr auto
 just(Types&&... v)
 {
   if constexpr (sizeof...(Types) > 1)
@@ -644,7 +648,7 @@ just(Types&&... v)
 }
 
 template <class Target = void, class T, class... Types>
-auto
+constexpr auto
 just(std::initializer_list<T> il, Types&&... v)
 {
   return just_t<
@@ -661,7 +665,7 @@ class [[nodiscard]] just_t<_just_detail::forward_mode<T>, Args...>
 public:
   constexpr explicit just_t(Args... args) : args(std::forward<Args>(args)...) {}
 
-  auto operator()() &&
+  constexpr auto operator()() &&
   {
     return std::apply(
         [](auto&&... fwd)

--- a/include/mitama/maybe/factory/just_nothing.hpp
+++ b/include/mitama/maybe/factory/just_nothing.hpp
@@ -117,8 +117,7 @@ public:
   template <class U>
     requires not_self<std::decay_t<U>>::value
              && std::is_constructible_v<T, U> && (!std::is_convertible_v<U, T>)
-  explicit constexpr just_t(
-      U&& u
+  explicit constexpr just_t(U&& u
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::forward<U>(u))
   {
@@ -127,8 +126,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, const U&>
             && std::is_convertible_v<const U&, T>
-  constexpr just_t(
-      const just_t<U>& t
+  constexpr just_t(const just_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(t.get())
   {
@@ -137,8 +135,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, const U&>
             && (!std::is_convertible_v<const U&, T>)
-  explicit constexpr just_t(
-      const just_t<U>& t
+  explicit constexpr just_t(const just_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(t.get())
   {
@@ -147,8 +144,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>)
             && std::is_constructible_v<T, U&&> && std::is_convertible_v<U&&, T>
-  constexpr just_t(just_t<U>&& t) noexcept(std::is_nothrow_constructible_v<T, U>
-  )
+  constexpr just_t(just_t<U>&& t
+  ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::move(t.get()))
   {
   }
@@ -156,8 +153,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, U&&>
             && (!std::is_convertible_v<U &&, T>)
-  explicit constexpr just_t(
-      just_t<U>&& t
+  explicit constexpr just_t(just_t<U>&& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::move(t.get()))
   {

--- a/include/mitama/maybe/maybe.hpp
+++ b/include/mitama/maybe/maybe.hpp
@@ -18,10 +18,12 @@
 #include <variant>
 #include <version>
 
-#if __cpp_lib_variant >= 202106L
-#  define MITAMA_VARIANT_CONSTEXPR constexpr
-#else
-#  define MITAMA_VARIANT_CONSTEXPR
+#ifndef MITAMA_VARIANT_CONSTEXPR
+#  if __cpp_lib_variant >= 202106L
+#    define MITAMA_VARIANT_CONSTEXPR constexpr
+#  else
+#    define MITAMA_VARIANT_CONSTEXPR
+#  endif
 #endif
 
 namespace mitama::mitamagic

--- a/include/mitama/maybe/maybe.hpp
+++ b/include/mitama/maybe/maybe.hpp
@@ -471,13 +471,11 @@ public:
   constexpr auto map(F&& f, Args&&... args) &
   {
     using result_type = std::invoke_result_t<F&&, value_type&, Args&&...>;
-    return is_just() ? maybe<result_type>{ just(
-                           std::invoke(
-                               std::forward<F>(f), unwrap(),
-                               std::forward<Args>(args)...
-                           )
-                       ) }
-                     : nothing;
+    return is_just()
+               ? maybe<result_type>{ just(std::invoke(
+                     std::forward<F>(f), unwrap(), std::forward<Args>(args)...
+                 )) }
+               : nothing;
   }
 
   template <class F, class... Args>
@@ -485,13 +483,11 @@ public:
   constexpr auto map(F&& f, Args&&... args) const&
   {
     using result_type = std::invoke_result_t<F&&, const value_type&, Args&&...>;
-    return is_just() ? maybe<result_type>{ just(
-                           std::invoke(
-                               std::forward<F>(f), unwrap(),
-                               std::forward<Args>(args)...
-                           )
-                       ) }
-                     : nothing;
+    return is_just()
+               ? maybe<result_type>{ just(std::invoke(
+                     std::forward<F>(f), unwrap(), std::forward<Args>(args)...
+                 )) }
+               : nothing;
   }
 
   template <class F, class... Args>
@@ -499,12 +495,10 @@ public:
   constexpr auto map(F&& f, Args&&... args) &&
   {
     using result_type = std::invoke_result_t<F&&, value_type&&, Args&&...>;
-    return is_just() ? maybe<result_type>{ just(
-                           std::invoke(
-                               std::forward<F>(f), std::move(unwrap()),
-                               std::forward<Args>(args)...
-                           )
-                       ) }
+    return is_just() ? maybe<result_type>{ just(std::invoke(
+                           std::forward<F>(f), std::move(unwrap()),
+                           std::forward<Args>(args)...
+                       )) }
                      : nothing;
   }
 

--- a/include/mitama/maybe/maybe.hpp
+++ b/include/mitama/maybe/maybe.hpp
@@ -883,7 +883,7 @@ public:
 
   template <class F>
     requires std::is_invocable_v<F, value_type&> || std::is_invocable_v<F>
-  constexpr constexpr maybe& and_peek(F&& f) &
+  constexpr maybe& and_peek(F&& f) &
   {
     if (is_just())
     {

--- a/include/mitama/maybe/maybe.hpp
+++ b/include/mitama/maybe/maybe.hpp
@@ -1204,5 +1204,3 @@ template <class T>
 struct fmt::formatter<mitama::maybe<T>> : ostream_formatter
 {
 };
-
-#undef MITAMA_VARIANT_CONSTEXPR

--- a/include/mitama/maybe/range_to_maybe.hpp
+++ b/include/mitama/maybe/range_to_maybe.hpp
@@ -23,7 +23,7 @@ concept is_adl_range = requires(Range range) {
 namespace mitama
 {
 template <class Range>
-auto
+constexpr auto
 range_to_maybe(Range&& range)
 {
   if constexpr (_range_to_maybe_detail::is_std_range<Range>)

--- a/include/mitama/result/detail/dangling.hpp
+++ b/include/mitama/result/detail/dangling.hpp
@@ -17,7 +17,7 @@ public:
   {
   }
 
-  decltype(auto) transmute() const
+  constexpr decltype(auto) transmute() const
   {
     return value_;
   }
@@ -31,7 +31,7 @@ class dangling<std::reference_wrapper<T>>
 public:
   constexpr explicit dangling(std::reference_wrapper<T> ref) : ref_(ref) {}
 
-  T& transmute() const&
+  constexpr T& transmute() const&
   {
     return ref_.get();
   }

--- a/include/mitama/result/detail/result_impl.hpp
+++ b/include/mitama/result/detail/result_impl.hpp
@@ -830,10 +830,8 @@ public:
                : static_cast<result_type>(failure_t{ std::apply(
                      std::forward<O>(op),
                      std::tuple_cat(
-                         std::move(
-                             static_cast<basic_result<_mu, T, E>*>(this)
-                                 ->unwrap_err()
-                         ),
+                         std::move(static_cast<basic_result<_mu, T, E>*>(this)
+                                       ->unwrap_err()),
                          std::forward_as_tuple(std::forward<Args>(args))...
                      )
                  ) });
@@ -914,10 +912,10 @@ public:
                          std::forward_as_tuple(std::forward<Args>(args))...
                      )
                  ))
-               : static_cast<result_type>(failure(
-                     static_cast<const basic_result<_mu, T, E>*>(this)
-                         ->unwrap_err()
-                 ));
+               : static_cast<result_type>(
+                     failure(static_cast<const basic_result<_mu, T, E>*>(this)
+                                 ->unwrap_err())
+                 );
   }
 
   template <class O, class... Args>
@@ -944,19 +942,14 @@ public:
                ? static_cast<result_type>(std::apply(
                      std::forward<O>(op),
                      std::tuple_cat(
-                         std::move(
-                             static_cast<basic_result<_mu, T, E>*>(this)
-                                 ->unwrap()
-                         ),
+                         std::move(static_cast<basic_result<_mu, T, E>*>(this)
+                                       ->unwrap()),
                          std::forward_as_tuple(std::forward<Args>(args)...)
                      )
                  ))
-               : static_cast<result_type>(failure(
-                     std::move(
-                         static_cast<basic_result<_mu, T, E>*>(this)
-                             ->unwrap_err()
-                     )
-                 ));
+               : static_cast<result_type>(failure(std::move(
+                     static_cast<basic_result<_mu, T, E>*>(this)->unwrap_err()
+                 )));
   }
 };
 

--- a/include/mitama/result/detail/result_impl.hpp
+++ b/include/mitama/result/detail/result_impl.hpp
@@ -37,7 +37,7 @@ public:
   ///   Consumes the self argument then,
   ///   if success, returns the contained value,
   ///   otherwise; if Err, returns the default value for that type.
-  T unwrap_or_default() const
+  constexpr T unwrap_or_default() const
   {
     if constexpr (std::is_aggregate_v<T>)
     {
@@ -74,7 +74,7 @@ public:
   ///   Consumes the self argument then,
   ///   if success, returns the contained value,
   ///   otherwise; if failure, returns the default value for that type.
-  maybe<basic_result<_mutability, T, E>> transpose() const&
+  constexpr maybe<basic_result<_mutability, T, E>> transpose() const&
   {
     if (static_cast<const basic_result<_mutability, maybe<T>, E>*>(this)->is_ok(
         ))
@@ -830,8 +830,10 @@ public:
                : static_cast<result_type>(failure_t{ std::apply(
                      std::forward<O>(op),
                      std::tuple_cat(
-                         std::move(static_cast<basic_result<_mu, T, E>*>(this)
-                                       ->unwrap_err()),
+                         std::move(
+                             static_cast<basic_result<_mu, T, E>*>(this)
+                                 ->unwrap_err()
+                         ),
                          std::forward_as_tuple(std::forward<Args>(args))...
                      )
                  ) });
@@ -912,10 +914,10 @@ public:
                          std::forward_as_tuple(std::forward<Args>(args))...
                      )
                  ))
-               : static_cast<result_type>(
-                     failure(static_cast<const basic_result<_mu, T, E>*>(this)
-                                 ->unwrap_err())
-                 );
+               : static_cast<result_type>(failure(
+                     static_cast<const basic_result<_mu, T, E>*>(this)
+                         ->unwrap_err()
+                 ));
   }
 
   template <class O, class... Args>
@@ -942,14 +944,19 @@ public:
                ? static_cast<result_type>(std::apply(
                      std::forward<O>(op),
                      std::tuple_cat(
-                         std::move(static_cast<basic_result<_mu, T, E>*>(this)
-                                       ->unwrap()),
+                         std::move(
+                             static_cast<basic_result<_mu, T, E>*>(this)
+                                 ->unwrap()
+                         ),
                          std::forward_as_tuple(std::forward<Args>(args)...)
                      )
                  ))
-               : static_cast<result_type>(failure(std::move(
-                     static_cast<basic_result<_mu, T, E>*>(this)->unwrap_err()
-                 )));
+               : static_cast<result_type>(failure(
+                     std::move(
+                         static_cast<basic_result<_mu, T, E>*>(this)
+                             ->unwrap_err()
+                     )
+                 ));
   }
 };
 

--- a/include/mitama/result/factory/failure.hpp
+++ b/include/mitama/result/factory/failure.hpp
@@ -44,8 +44,7 @@ public:
   template <class U>
     requires not_self<std::decay_t<U>>::value
              && std::is_constructible_v<E, U> && (!std::is_convertible_v<U, E>)
-  explicit constexpr failure_t(
-      U&& u
+  explicit constexpr failure_t(U&& u
   ) noexcept(std::is_nothrow_constructible_v<E, U>)
       : x(std::forward<U>(u))
   {
@@ -54,8 +53,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<E, U>) && std::is_constructible_v<E, const U&>
             && std::is_convertible_v<const U&, E>
-  constexpr failure_t(
-      const failure_t<U>& t
+  constexpr failure_t(const failure_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<E, U>)
       : x(t.get())
   {
@@ -64,8 +62,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<E, U>) && std::is_constructible_v<E, const U&>
             && (!std::is_convertible_v<const U&, E>)
-  explicit constexpr failure_t(
-      const failure_t<U>& t
+  explicit constexpr failure_t(const failure_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<E, U>)
       : x(t.get())
   {
@@ -74,8 +71,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<E, U>)
             && std::is_constructible_v<E, U&&> && std::is_convertible_v<U&&, E>
-  constexpr failure_t(
-      failure_t<U>&& t
+  constexpr failure_t(failure_t<U>&& t
   ) noexcept(std::is_nothrow_constructible_v<E, U>)
       : x(std::move(t.get()))
   {
@@ -84,8 +80,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<E, U>) && std::is_constructible_v<E, U&&>
             && (!std::is_convertible_v<U &&, E>)
-  explicit constexpr failure_t(
-      failure_t<U>&& t
+  explicit constexpr failure_t(failure_t<U>&& t
   ) noexcept(std::is_nothrow_constructible_v<E, U>)
       : x(std::move(t.get()))
   {

--- a/include/mitama/result/factory/failure.hpp
+++ b/include/mitama/result/factory/failure.hpp
@@ -44,7 +44,8 @@ public:
   template <class U>
     requires not_self<std::decay_t<U>>::value
              && std::is_constructible_v<E, U> && (!std::is_convertible_v<U, E>)
-  explicit constexpr failure_t(U&& u
+  explicit constexpr failure_t(
+      U&& u
   ) noexcept(std::is_nothrow_constructible_v<E, U>)
       : x(std::forward<U>(u))
   {
@@ -53,7 +54,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<E, U>) && std::is_constructible_v<E, const U&>
             && std::is_convertible_v<const U&, E>
-  constexpr failure_t(const failure_t<U>& t
+  constexpr failure_t(
+      const failure_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<E, U>)
       : x(t.get())
   {
@@ -62,7 +64,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<E, U>) && std::is_constructible_v<E, const U&>
             && (!std::is_convertible_v<const U&, E>)
-  explicit constexpr failure_t(const failure_t<U>& t
+  explicit constexpr failure_t(
+      const failure_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<E, U>)
       : x(t.get())
   {
@@ -71,7 +74,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<E, U>)
             && std::is_constructible_v<E, U&&> && std::is_convertible_v<U&&, E>
-  constexpr failure_t(failure_t<U>&& t
+  constexpr failure_t(
+      failure_t<U>&& t
   ) noexcept(std::is_nothrow_constructible_v<E, U>)
       : x(std::move(t.get()))
   {
@@ -80,7 +84,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<E, U>) && std::is_constructible_v<E, U&&>
             && (!std::is_convertible_v<U &&, E>)
-  explicit constexpr failure_t(failure_t<U>&& t
+  explicit constexpr failure_t(
+      failure_t<U>&& t
   ) noexcept(std::is_nothrow_constructible_v<E, U>)
       : x(std::move(t.get()))
   {
@@ -223,15 +228,15 @@ public:
     return rhs <= *this;
   }
 
-  E& get() &
+  constexpr E& get() &
   {
     return x;
   }
-  const E& get() const&
+  constexpr const E& get() const&
   {
     return x;
   }
-  E&& get() &&
+  constexpr E&& get() &&
   {
     return std::move(x);
   }
@@ -396,15 +401,15 @@ public:
     return rhs <= *this;
   }
 
-  E& get() &
+  constexpr E& get() &
   {
     return x.get();
   }
-  const E& get() const&
+  constexpr const E& get() const&
   {
     return x.get();
   }
-  E& get() &&
+  constexpr E& get() &&
   {
     return x.get();
   }
@@ -420,7 +425,7 @@ public:
   {
   }
 
-  auto operator()() &&
+  constexpr auto operator()() &&
   {
     return std::apply(
         [](auto&&... fwd)
@@ -431,7 +436,7 @@ public:
 };
 
 template <class Target = void, class... Types>
-inline auto
+inline constexpr auto
 failure(Types&&... v)
 {
   if constexpr (!std::is_void_v<Target>)

--- a/include/mitama/result/factory/success.hpp
+++ b/include/mitama/result/factory/success.hpp
@@ -44,7 +44,8 @@ public:
   template <class U>
     requires not_self<std::decay_t<U>>::value
              && std::is_constructible_v<T, U> && (!std::is_convertible_v<U, T>)
-  explicit constexpr success_t(U&& u
+  explicit constexpr success_t(
+      U&& u
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::forward<U>(u))
   {
@@ -53,7 +54,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, const U&>
             && std::is_convertible_v<const U&, T>
-  constexpr success_t(const success_t<U>& t
+  constexpr success_t(
+      const success_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(t.get())
   {
@@ -62,7 +64,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, const U&>
             && (!std::is_convertible_v<const U&, T>)
-  explicit constexpr success_t(const success_t<U>& t
+  explicit constexpr success_t(
+      const success_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(t.get())
   {
@@ -71,7 +74,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>)
             && std::is_constructible_v<T, U&&> && std::is_convertible_v<U&&, T>
-  constexpr success_t(success_t<U>&& t
+  constexpr success_t(
+      success_t<U>&& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::move(t.get()))
   {
@@ -80,7 +84,8 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, U&&>
             && (!std::is_convertible_v<U &&, T>)
-  explicit constexpr success_t(success_t<U>&& t
+  explicit constexpr success_t(
+      success_t<U>&& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::move(t.get()))
   {
@@ -220,15 +225,15 @@ public:
     return true;
   }
 
-  T& get() &
+  constexpr T& get() &
   {
     return x;
   }
-  const T& get() const&
+  constexpr const T& get() const&
   {
     return x;
   }
-  T&& get() &&
+  constexpr T&& get() &&
   {
     return std::move(x);
   }
@@ -390,15 +395,15 @@ public:
     return true;
   }
 
-  T& get() &
+  constexpr T& get() &
   {
     return x.get();
   }
-  const T& get() const&
+  constexpr const T& get() const&
   {
     return x.get();
   }
-  T& get() &&
+  constexpr T& get() &&
   {
     return x.get();
   }
@@ -414,7 +419,7 @@ public:
   {
   }
 
-  auto operator()() &&
+  constexpr auto operator()() &&
   {
     return std::apply(
         [](auto&&... fwd)
@@ -425,7 +430,7 @@ public:
 };
 
 template <class Target = void, class... Types>
-inline auto
+inline constexpr auto
 success(Types&&... v)
 {
   if constexpr (!std::is_void_v<Target>)

--- a/include/mitama/result/factory/success.hpp
+++ b/include/mitama/result/factory/success.hpp
@@ -44,8 +44,7 @@ public:
   template <class U>
     requires not_self<std::decay_t<U>>::value
              && std::is_constructible_v<T, U> && (!std::is_convertible_v<U, T>)
-  explicit constexpr success_t(
-      U&& u
+  explicit constexpr success_t(U&& u
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::forward<U>(u))
   {
@@ -54,8 +53,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, const U&>
             && std::is_convertible_v<const U&, T>
-  constexpr success_t(
-      const success_t<U>& t
+  constexpr success_t(const success_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(t.get())
   {
@@ -64,8 +62,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, const U&>
             && (!std::is_convertible_v<const U&, T>)
-  explicit constexpr success_t(
-      const success_t<U>& t
+  explicit constexpr success_t(const success_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(t.get())
   {
@@ -74,8 +71,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>)
             && std::is_constructible_v<T, U&&> && std::is_convertible_v<U&&, T>
-  constexpr success_t(
-      success_t<U>&& t
+  constexpr success_t(success_t<U>&& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::move(t.get()))
   {
@@ -84,8 +80,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, U&&>
             && (!std::is_convertible_v<U &&, T>)
-  explicit constexpr success_t(
-      success_t<U>&& t
+  explicit constexpr success_t(success_t<U>&& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::move(t.get()))
   {

--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -625,10 +625,8 @@ public:
   /// @brief
   ///   Produces a new basic_result, containing a reference into the original,
   ///   leaving the original in place.
-  constexpr auto
-  as_ref() const& noexcept -> basic_result<
-                               _mutability, const std::remove_cvref_t<T>&,
-                               const std::remove_cvref_t<E>&>
+  constexpr auto as_ref() const& noexcept -> basic_result<
+      _mutability, const std::remove_cvref_t<T>&, const std::remove_cvref_t<E>&>
   {
     if (is_ok())
     {
@@ -651,10 +649,9 @@ public:
   /// @brief
   ///   Converts from `basic_result<mutability::mut, T, E>&` to
   ///   `basic_result<mutability::immut, T&, E&>`.
-  constexpr auto
-  as_mut() & noexcept -> basic_result<
-                          mutability::immut, std::remove_reference_t<T>&,
-                          std::remove_reference_t<E>&>
+  constexpr auto as_mut() & noexcept -> basic_result<
+      mutability::immut, std::remove_reference_t<T>&,
+      std::remove_reference_t<E>&>
   {
     static_assert(
         !std::is_const_v<std::remove_reference_t<T>>,
@@ -2019,8 +2016,8 @@ public:
   }
 
   template <class Ctx>
-  auto with_context(Ctx ctx
-  ) -> basic_result<_mutability, T, std::shared_ptr<anyhow::error>>
+  auto with_context(Ctx ctx)
+      -> basic_result<_mutability, T, std::shared_ptr<anyhow::error>>
     requires std::is_invocable_r_v<std::shared_ptr<anyhow::error>, Ctx>
   {
     return this->map_err(

--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -20,10 +20,12 @@
 #include <variant>
 #include <version>
 
-#if __cpp_lib_variant >= 202106L
-#  define MITAMA_VARIANT_CONSTEXPR constexpr
-#else
-#  define MITAMA_VARIANT_CONSTEXPR
+#ifndef MITAMA_VARIANT_CONSTEXPR
+#  if __cpp_lib_variant >= 202106L
+#    define MITAMA_VARIANT_CONSTEXPR constexpr
+#  else
+#    define MITAMA_VARIANT_CONSTEXPR
+#  endif
 #endif
 
 namespace mitama::_result_detail
@@ -235,7 +237,8 @@ public:
   ///   copy assignment operator for convertible basic_result
   template <mutability _mu, class U, class F>
     requires std::is_constructible_v<T, U> && std::is_constructible_v<E, F>
-  MITAMA_VARIANT_CONSTEXPR basic_result& operator=(const basic_result<_mu, U, F>& res)
+  MITAMA_VARIANT_CONSTEXPR basic_result&
+  operator=(const basic_result<_mu, U, F>& res)
   {
     static_assert(
         is_mut_v<_mutability>, "Error: assignment to immutable result"
@@ -255,7 +258,8 @@ public:
   ///   move assignment operator for convertible basic_result
   template <mutability _mu, class U, class F>
     requires std::is_constructible_v<T, U> && std::is_constructible_v<E, F>
-  MITAMA_VARIANT_CONSTEXPR basic_result& operator=(basic_result<_mu, U, F>&& res)
+  MITAMA_VARIANT_CONSTEXPR basic_result& operator=(basic_result<_mu, U, F>&& res
+  )
   {
     static_assert(
         is_mut_v<_mutability>, "Error: assignment to immutable result"

--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -625,8 +625,10 @@ public:
   /// @brief
   ///   Produces a new basic_result, containing a reference into the original,
   ///   leaving the original in place.
-  constexpr auto as_ref() const& noexcept -> basic_result<
-      _mutability, const std::remove_cvref_t<T>&, const std::remove_cvref_t<E>&>
+  constexpr auto
+  as_ref() const& noexcept -> basic_result<
+                               _mutability, const std::remove_cvref_t<T>&,
+                               const std::remove_cvref_t<E>&>
   {
     if (is_ok())
     {
@@ -649,9 +651,10 @@ public:
   /// @brief
   ///   Converts from `basic_result<mutability::mut, T, E>&` to
   ///   `basic_result<mutability::immut, T&, E&>`.
-  constexpr auto as_mut() & noexcept -> basic_result<
-      mutability::immut, std::remove_reference_t<T>&,
-      std::remove_reference_t<E>&>
+  constexpr auto
+  as_mut() & noexcept -> basic_result<
+                          mutability::immut, std::remove_reference_t<T>&,
+                          std::remove_reference_t<E>&>
   {
     static_assert(
         !std::is_const_v<std::remove_reference_t<T>>,
@@ -855,10 +858,9 @@ public:
   ///   This function can be used to unpack a successful result while handling
   ///   an error.
   template <class Map, class Fallback>
-  constexpr auto map_or_else(Fallback&& _fallback, Map&& _map) & noexcept(
-      std::is_nothrow_invocable_v<Fallback, E>
-      && std::is_nothrow_invocable_v<Map, T>
-  )
+  constexpr auto map_or_else(
+      Fallback&& _fallback, Map&& _map
+  ) & noexcept(std::is_nothrow_invocable_v<Fallback, E> && std::is_nothrow_invocable_v<Map, T>)
       -> std::common_type_t<
           std::invoke_result_t<Map, T>, std::invoke_result_t<Fallback, E>>
     requires std::is_invocable_v<Map, T&> && std::is_invocable_v<Fallback, E&>
@@ -895,10 +897,9 @@ public:
   ///   This function can be used to unpack a successful result while handling
   ///   an error.
   template <class Map, class Fallback>
-  constexpr auto map_or_else(Fallback&& _fallback, Map&& _map) const& noexcept(
-      std::is_nothrow_invocable_v<Fallback, E>
-      && std::is_nothrow_invocable_v<Map, T>
-  )
+  constexpr auto map_or_else(
+      Fallback&& _fallback, Map&& _map
+  ) const& noexcept(std::is_nothrow_invocable_v<Fallback, E> && std::is_nothrow_invocable_v<Map, T>)
       -> std::common_type_t<
           std::invoke_result_t<Map, T>, std::invoke_result_t<Fallback, E>>
     requires std::is_invocable_v<Map, T> && std::is_invocable_v<Fallback, E>
@@ -935,10 +936,9 @@ public:
   ///   This function can be used to unpack a successful result while handling
   ///   an error.
   template <class Map, class Fallback>
-  constexpr auto map_or_else(Fallback&& _fallback, Map&& _map) && noexcept(
-      std::is_nothrow_invocable_v<Fallback, E>
-      && std::is_nothrow_invocable_v<Map, T>
-  )
+  constexpr auto map_or_else(
+      Fallback&& _fallback, Map&& _map
+  ) && noexcept(std::is_nothrow_invocable_v<Fallback, E> && std::is_nothrow_invocable_v<Map, T>)
       -> std::common_type_t<
           std::invoke_result_t<Map, T>, std::invoke_result_t<Fallback, E>>
     requires std::is_invocable_v<Map, T> && std::is_invocable_v<Fallback, E>
@@ -972,12 +972,11 @@ public:
   ///   This function can be used to pass through a successful result while
   ///   handling an error. result<T, E> -> result<T, F>
   template <class O, class... Args>
-  constexpr auto map_err(
-      O&& op, Args&&... args
-  ) const& noexcept(std::is_nothrow_invocable_v<O, E, Args&&...>)
-      -> basic_result<
-          _mutability, T,
-          void_to_monostate_t<std::invoke_result_t<O, E, Args&&...>>>
+  constexpr auto map_err(O&& op, Args&&... args)
+      const& noexcept(std::is_nothrow_invocable_v<O, E, Args&&...>)
+          -> basic_result<
+              _mutability, T,
+              void_to_monostate_t<std::invoke_result_t<O, E, Args&&...>>>
     requires std::is_invocable_v<O, E, Args&&...>
   {
     using result_type = basic_result<
@@ -1013,12 +1012,11 @@ public:
   ///   This function can be used to pass through a successful result while
   ///   handling an error. result<T, void> -> result<T, F>
   template <class O, class... Args>
-  constexpr auto map_err(
-      O&& op, Args&&... args
-  ) const& noexcept(std::is_nothrow_invocable_v<O, Args&&...>)
-      -> basic_result<
-          _mutability, T,
-          void_to_monostate_t<std::invoke_result_t<O, Args&&...>>>
+  constexpr auto map_err(O&& op, Args&&... args)
+      const& noexcept(std::is_nothrow_invocable_v<O, Args&&...>)
+          -> basic_result<
+              _mutability, T,
+              void_to_monostate_t<std::invoke_result_t<O, Args&&...>>>
     requires std::is_same_v<E, std::monostate>
              && std::is_invocable_v<O, Args&&...>
   {
@@ -1131,9 +1129,9 @@ public:
   /// @note
   ///   This function can be used for control flow based on result values.
   template <class O, class... Args>
-  constexpr auto and_then(O&& op, Args&&... args) const& noexcept(
-      std::is_nothrow_invocable_v<O, T, Args&&...>
-  ) -> std::invoke_result_t<O, T, Args&&...>
+  constexpr auto and_then(O&& op, Args&&... args)
+      const& noexcept(std::is_nothrow_invocable_v<O, T, Args&&...>)
+          -> std::invoke_result_t<O, T, Args&&...>
     requires is_convertible_result_with_v<
         std::invoke_result_t<O, T, Args&&...>, failure_t<E>>
   {
@@ -1158,9 +1156,10 @@ public:
   /// @note
   ///   This function can be used for control flow based on result values.
   template <class O, class... Args>
-  constexpr auto and_then(O&& op, Args&&... args) && noexcept(
-      std::is_nothrow_invocable_v<O, T, Args&&...>
-  ) -> std::invoke_result_t<O, T, Args&&...>
+  constexpr auto and_then(
+      O&& op, Args&&... args
+  ) && noexcept(std::is_nothrow_invocable_v<O, T, Args&&...>)
+      -> std::invoke_result_t<O, T, Args&&...>
     requires is_convertible_result_with_v<
         std::invoke_result_t<O, T, Args&&...>, failure_t<E>>
   {
@@ -1185,9 +1184,9 @@ public:
   /// @note
   ///   This function can be used for control flow based on result values.
   template <class O, class... Args>
-  constexpr auto or_else(O&& op, Args&&... args) const& noexcept(
-      std::is_nothrow_invocable_v<O, E, Args&&...>
-  ) -> std::invoke_result_t<O, E, Args&&...>
+  constexpr auto or_else(O&& op, Args&&... args)
+      const& noexcept(std::is_nothrow_invocable_v<O, E, Args&&...>)
+          -> std::invoke_result_t<O, E, Args&&...>
     requires is_convertible_result_with_v<
         std::invoke_result_t<O, T, Args&&...>, success_t<T>>
   {
@@ -1211,9 +1210,10 @@ public:
   /// @note
   ///   This function can be used for control flow based on result values.
   template <class O, class... Args>
-  constexpr auto or_else(O&& op, Args&&... args) && noexcept(
-      std::is_nothrow_invocable_v<O, E, Args&&...>
-  ) -> std::invoke_result_t<O, E, Args&&...>
+  constexpr auto or_else(
+      O&& op, Args&&... args
+  ) && noexcept(std::is_nothrow_invocable_v<O, E, Args&&...>)
+      -> std::invoke_result_t<O, E, Args&&...>
     requires is_convertible_result_with_v<
         std::invoke_result_t<O, T, Args&&...>, success_t<T>>
   {
@@ -1231,8 +1231,8 @@ public:
   ///   Returns `res` if the result is success_t, otherwise; returns the failure
   ///   value of self.
   template <mutability _mu, class U>
-  constexpr decltype(auto)
-  conj(const basic_result<_mu, U, E>& res) const& noexcept
+  constexpr decltype(auto) conj(const basic_result<_mu, U, E>& res
+  ) const& noexcept
   {
     using result_type = basic_result<_mutability && _mu, U, E>;
     return this->is_err() ? static_cast<result_type>(failure_t{
@@ -1262,8 +1262,8 @@ public:
   ///   it is recommended to use `or_else`,
   ///   which is lazily evaluated.
   template <mutability _mut, class F>
-  constexpr decltype(auto)
-  disj(const basic_result<_mut, T, F>& res) const& noexcept
+  constexpr decltype(auto) disj(const basic_result<_mut, T, F>& res
+  ) const& noexcept
   {
     using result_type = basic_result<_mutability, T, F>;
     return this->is_ok() ? static_cast<result_type>(success_t{
@@ -1345,14 +1345,14 @@ public:
   ///     - otherwise; static_assert.
   template <class O>
     requires std::is_invocable_r_v<T, O, E> || std::is_invocable_r_v<T, O>
-  constexpr T unwrap_or_else(O&& op) const noexcept(
-      std::disjunction_v<
-          std::conjunction<
-              std::is_invocable_r<T, O, E>,
-              std::is_nothrow_invocable_r<T, O, E>>,
-          std::conjunction<
-              std::is_invocable_r<T, O>, std::is_nothrow_invocable_r<T, O>>>
-  )
+  constexpr T unwrap_or_else(O&& op) const
+      noexcept(std::disjunction_v<
+               std::conjunction<
+                   std::is_invocable_r<T, O, E>,
+                   std::is_nothrow_invocable_r<T, O, E>>,
+               std::conjunction<
+                   std::is_invocable_r<T, O>,
+                   std::is_nothrow_invocable_r<T, O>>>)
   {
     if constexpr (std::is_invocable_r_v<T, O, E>)
     {
@@ -1709,9 +1709,8 @@ public:
   }
 
   template <class F>
-  constexpr auto map_anything_else(F&& f) & noexcept(
-      std::is_nothrow_invocable_v<F, E&> && std::is_nothrow_invocable_v<F, T&>
-  )
+  constexpr auto map_anything_else(F&& f
+  ) & noexcept(std::is_nothrow_invocable_v<F, E&> && std::is_nothrow_invocable_v<F, T&>)
       -> std::common_type_t<
           std::invoke_result_t<F, T&>, std::invoke_result_t<F, E&>>
     requires std::is_invocable_v<F, T&> && std::is_invocable_v<F, E&>
@@ -1730,10 +1729,8 @@ public:
   }
 
   template <class F>
-  constexpr auto map_anything_else(F&& f) const& noexcept(
-      std::is_nothrow_invocable_v<F, const E&>
-      && std::is_nothrow_invocable_v<F, const T&>
-  )
+  constexpr auto map_anything_else(F&& f
+  ) const& noexcept(std::is_nothrow_invocable_v<F, const E&> && std::is_nothrow_invocable_v<F, const T&>)
       -> std::common_type_t<
           std::invoke_result_t<F, const T&>, std::invoke_result_t<F, const E&>>
     requires std::is_invocable_v<F, const T&>
@@ -1755,9 +1752,8 @@ public:
   }
 
   template <class F>
-  constexpr auto map_anything_else(F&& f) && noexcept(
-      std::is_nothrow_invocable_v<F, E&&> && std::is_nothrow_invocable_v<F, T&&>
-  )
+  constexpr auto map_anything_else(F&& f
+  ) && noexcept(std::is_nothrow_invocable_v<F, E&&> && std::is_nothrow_invocable_v<F, T&&>)
       -> std::common_type_t<
           std::invoke_result_t<F, T&&>, std::invoke_result_t<F, E&&>>
     requires std::is_invocable_v<F, T&&> && std::is_invocable_v<F, E&&>
@@ -2023,8 +2019,8 @@ public:
   }
 
   template <class Ctx>
-  auto with_context(Ctx ctx)
-      -> basic_result<_mutability, T, std::shared_ptr<anyhow::error>>
+  auto with_context(Ctx ctx
+  ) -> basic_result<_mutability, T, std::shared_ptr<anyhow::error>>
     requires std::is_invocable_r_v<std::shared_ptr<anyhow::error>, Ctx>
   {
     return this->map_err(

--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -235,7 +235,7 @@ public:
   ///   copy assignment operator for convertible basic_result
   template <mutability _mu, class U, class F>
     requires std::is_constructible_v<T, U> && std::is_constructible_v<E, F>
-  constexpr basic_result& operator=(const basic_result<_mu, U, F>& res)
+  MITAMA_VARIANT_CONSTEXPR basic_result& operator=(const basic_result<_mu, U, F>& res)
   {
     static_assert(
         is_mut_v<_mutability>, "Error: assignment to immutable result"
@@ -255,7 +255,7 @@ public:
   ///   move assignment operator for convertible basic_result
   template <mutability _mu, class U, class F>
     requires std::is_constructible_v<T, U> && std::is_constructible_v<E, F>
-  constexpr basic_result& operator=(basic_result<_mu, U, F>&& res)
+  MITAMA_VARIANT_CONSTEXPR basic_result& operator=(basic_result<_mu, U, F>&& res)
   {
     static_assert(
         is_mut_v<_mutability>, "Error: assignment to immutable result"
@@ -275,7 +275,7 @@ public:
   ///   copy assignment operator for convertible success_t
   template <class U>
     requires std::is_constructible_v<T, U>
-  constexpr basic_result& operator=(const success_t<U>& _ok)
+  MITAMA_VARIANT_CONSTEXPR basic_result& operator=(const success_t<U>& _ok)
   {
     static_assert(
         is_mut_v<_mutability>, "Error: assignment to immutable result"
@@ -288,7 +288,7 @@ public:
   ///   copy assignment operator for convertible failure_t
   template <class F>
     requires std::is_constructible_v<E, F>
-  constexpr basic_result& operator=(const failure_t<F>& _err)
+  MITAMA_VARIANT_CONSTEXPR basic_result& operator=(const failure_t<F>& _err)
   {
     static_assert(
         is_mut_v<_mutability>, "Error: assignment to immutable result"
@@ -301,7 +301,7 @@ public:
   ///   move assignment operator for convertible success_t
   template <class U>
     requires std::is_constructible_v<T, U>
-  constexpr basic_result& operator=(success_t<U>&& _ok)
+  MITAMA_VARIANT_CONSTEXPR basic_result& operator=(success_t<U>&& _ok)
   {
     static_assert(
         is_mut_v<_mutability>, "Error: assignment to immutable result"
@@ -314,7 +314,7 @@ public:
   ///   move assignment operator for convertible failure_t
   template <class F>
     requires std::is_constructible_v<E, F>
-  constexpr basic_result& operator=(failure_t<F>&& _err)
+  MITAMA_VARIANT_CONSTEXPR basic_result& operator=(failure_t<F>&& _err)
   {
     static_assert(
         is_mut_v<_mutability>, "Error: assignment to immutable result"

--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -18,6 +18,7 @@
 #include <type_traits>
 #include <utility>
 #include <variant>
+#include <version>
 
 #if __cpp_lib_variant >= 202106L
 #  define MITAMA_VARIANT_CONSTEXPR constexpr

--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -2204,5 +2204,3 @@ operator>=(T&& lhs, const basic_result<_, U, E>& rhs)
 #  define MITAMA_CPP_RESULT_TRY_MAY_NOT_PANIC false
 #  define MITAMA_TRY(...) ::mitama::_result_detail::id(__VA_ARGS__).unwrap()
 #endif
-
-#undef MITAMA_VARIANT_CONSTEXPR

--- a/include/mitama/thiserror/thiserror.hpp
+++ b/include/mitama/thiserror/thiserror.hpp
@@ -79,7 +79,8 @@ public:
   friend std::ostream& operator<<(std::ostream& os, const error& err)
   {
     return os << std::apply(
-               [&](auto&&... src) {
+               [&](auto&&... src)
+               {
                  return fmt::format(fmt, std::forward<decltype(src)>(src)...);
                },
                err.sources

--- a/include/mitama/thiserror/thiserror.hpp
+++ b/include/mitama/thiserror/thiserror.hpp
@@ -79,8 +79,7 @@ public:
   friend std::ostream& operator<<(std::ostream& os, const error& err)
   {
     return os << std::apply(
-               [&](auto&&... src)
-               {
+               [&](auto&&... src) {
                  return fmt::format(fmt, std::forward<decltype(src)>(src)...);
                },
                err.sources


### PR DESCRIPTION
`std::variant` is almost `constexpr` and since [P2231R1](<https://wg21.link/P2231R1>) has adopted for C++23, more operations can be marked as `constexpr`.