### PR TITLE
Use format_string for runtime_panic

### DIFF
--- a/include/mitama/panic.hpp
+++ b/include/mitama/panic.hpp
@@ -2,11 +2,9 @@
 
 #include <mitama/mitamagic/format.hpp>
 
+#include <fmt/core.h>
 #include <stdexcept>
-#include <string>
-#include <string_view>
 #include <utility>
-#include <variant>
 
 namespace mitama
 {
@@ -16,12 +14,12 @@ class runtime_panic : public std::runtime_error
 public:
   template <class... Args>
   explicit runtime_panic(
-      const char* file, const int line, std::string_view f, Args&&... args
+      const char* file, const int line, fmt::format_string<Args...> f,
+      Args&&... args
   ) noexcept
       : std::runtime_error(fmt::format(
             "runtime panicked at '{}', {}:{}",
-            fmt::format(fmt::runtime(f), std::forward<Args>(args)...), file,
-            line
+            fmt::format(f, std::forward<Args>(args)...), file, line
         ))
   {
   }


### PR DESCRIPTION
This can avoid using fmt::runtime