### PR TITLE
Fix incorrect type constraints for basic_result constructors

### DIFF
--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -375,7 +375,7 @@ public:
   /// @brief
   ///   explicit constructor for unsuccessful lvalue
   template <class U>
-    requires std::is_constructible_v<T, U> && (!std::is_convertible_v<U, T>)
+    requires std::is_constructible_v<E, U> && (!std::is_convertible_v<U, E>)
   constexpr explicit basic_result(const failure_t<U>& err)
       : storage_{ std::in_place_type<failure_t<E>>, std::in_place, err.get() }
   {
@@ -393,7 +393,7 @@ public:
   /// @brief
   ///   explicit constructor for unsuccessful lvalue
   template <class U>
-    requires std::is_constructible_v<T, U> && (!std::is_convertible_v<U, T>)
+    requires std::is_constructible_v<E, U> && (!std::is_convertible_v<U, E>)
   constexpr explicit basic_result(failure_t<U>&& err)
       : storage_{ std::in_place_type<failure_t<E>>, std::move(err) }
   {


### PR DESCRIPTION
Some of the type constraints for the basic_result constructors that take failure_t check constructability and convertibility against T. However, T is unrelated in this context; use E instead.

See also: https://github.com/loliGothicK/mitama-cpp-result/pull/377/files#diff-5f2deecddbd2a0b580bb6983c6f3c6d1ea8c1895294f5a722b0793e6f271270cL332-L358