### PR TITLE
Remove operator bool from basic_result

### DIFF
--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -542,26 +542,6 @@ public:
   }
 
   /// @brief
-  ///   Converts from basic_result to bool.
-  ///
-  /// @note
-  ///   Covert result to bool and returns true if the result is succsess.
-  explicit constexpr operator bool() const noexcept
-  {
-    return std::holds_alternative<success_t<T>>(storage_);
-  }
-
-  /// @brief
-  ///   Converts from basic_result to bool.
-  ///
-  /// @note
-  ///   Covert result to bool and returns true if the result is failure.
-  constexpr bool operator!() const noexcept
-  {
-    return std::holds_alternative<failure_t<E>>(storage_);
-  }
-
-  /// @brief
   ///   Returns result storage.
   constexpr decltype(auto) into_storage() &
   {

--- a/test/result_tests.cpp
+++ b/test/result_tests.cpp
@@ -720,24 +720,6 @@ TEST_CASE("monostate failure test", "[result][monostate]")
   REQUIRE(func().is_err());
 }
 
-TEST_CASE("contextually convertible to bool", "[result]")
-{
-  auto err_func = []() -> result</*defaulted monostate*/>
-  {
-    if (false)
-      return failure<>();
-    return failure<>();
-  };
-  auto ok_func = []() -> result<void, std::string>
-  {
-    if (false)
-      return failure<std::string>("hoge"s);
-    return success<>();
-  };
-  REQUIRE(!err_func());
-  REQUIRE(ok_func());
-}
-
 SCENARIO("test for reference type", "[result][ref]")
 {
   using namespace std::literals;


### PR DESCRIPTION
Although implementing an operator bool for this kind of type is normal in the C++ context, this is error-prone.  As Rust does, it is preferable to avoid implicit conversion.