### PR TITLE
Remove default template arguments to result

### DIFF
--- a/docs/docs/result/APIs.md
+++ b/docs/docs/result/APIs.md
@@ -927,8 +927,8 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-    result<int> good = success(1909);
-    result<int> bad = failure<>();
+    result<int, void> good = success(1909);
+    result<int, void> bad = failure<>();
     auto good_year = good.unwrap_or_default();
     auto bad_year = bad.unwrap_or_default();
     assert(1909 == good_year);

--- a/docs/docs/result/intro.md
+++ b/docs/docs/result/intro.md
@@ -11,11 +11,7 @@ enum class mutability: bool {
 template < mutability Mut >
 inline constexpr bool is_mut_v = !static_cast<bool>(Mut);
 
-template <mutability,
-          class = std::monostate,   // success type
-          class = std::monostate,   // failure type
-          class = decltype(nullptr) // for detection idiom
->
+template <mutability, class /* success type */, class /* failure type */>
 class basic_result;
 ```
 
@@ -101,7 +97,7 @@ using namespace mitama;
 int main() {
   static_assert(!is_complete_type<incomplete_type>::value);
   [[maybe_unused]]
-  result<incomplete_type&> res = success<incomplete_type&>(get_incomplete_type()); // use incomplete_type& for result
+  result<incomplete_type&, void> res = success<incomplete_type&>(get_incomplete_type()); // use incomplete_type& for result
 }
 
 struct incomplete_type {};

--- a/include/mitama/boolinators.hpp
+++ b/include/mitama/boolinators.hpp
@@ -45,10 +45,10 @@ and_maybe_from(bool b, F&& may) -> std::invoke_result_t<F&&>
 }
 
 template <class T>
-inline constexpr result<T>
+inline constexpr result<T, void>
 as_ok(bool b, T&& ok)
 {
-  return b ? result<T>(success(std::forward<T>(ok))) : failure();
+  return b ? result<T, void>(success(std::forward<T>(ok))) : failure();
 }
 
 template <class T, class E>

--- a/include/mitama/result/detail/fwd.hpp
+++ b/include/mitama/result/detail/fwd.hpp
@@ -34,20 +34,16 @@ template <class T>
 using void_to_monostate_t =
     std::conditional_t<std::is_void_v<T>, std::monostate, T>;
 
-template <
-    mutability,
-    class = std::monostate, // success type
-    class = std::monostate // failure type
-    >
+template <mutability, class /* success type */, class /* failure type */>
 class basic_result;
 
 /// alias template for immutable result
-template <class T = std::monostate, class E = std::monostate>
+template <class T, class E>
 using result = basic_result<
     mutability::immut, void_to_monostate_t<T>, void_to_monostate_t<E>>;
 
 /// alias template for mutable result
-template <class T = std::monostate, class E = std::monostate>
+template <class T, class E>
 using mut_result = basic_result<
     mutability::mut, void_to_monostate_t<T>, void_to_monostate_t<E>>;
 

--- a/include/mitama/result/detail/fwd.hpp
+++ b/include/mitama/result/detail/fwd.hpp
@@ -37,8 +37,7 @@ using void_to_monostate_t =
 template <
     mutability,
     class = std::monostate, // success type
-    class = std::monostate, // failure type
-    class = std::nullptr_t // for detection idiom
+    class = std::monostate // failure type
     >
 class basic_result;
 

--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -170,7 +170,7 @@ class [[nodiscard]] basic_result<_mutability, T, E>
   /// result storage
   std::variant<std::monostate, success_t<T>, failure_t<E>> storage_;
   /// friend accessors
-  template <mutability, class, class, class>
+  template <mutability, class, class>
   friend class basic_result;
   /// private aliases
   template <mutability _mut, class T_, class E_>

--- a/test/result_tests.cpp
+++ b/test/result_tests.cpp
@@ -582,14 +582,14 @@ TEST_CASE("format test", "[result][format]")
   {
     using namespace std::literals;
     std::stringstream ss;
-    ss << result<>{ success() };
+    ss << result<void, void>{ success() };
     REQUIRE(ss.str() == "success(())"s);
   }
   SECTION("result of void err")
   {
     using namespace std::literals;
     std::stringstream ss;
-    ss << result<>{ failure() };
+    ss << result<void, void>{ failure() };
     REQUIRE(ss.str() == "failure(())"s);
   }
   SECTION("result of range ok")
@@ -711,7 +711,7 @@ TEST_CASE("monostate success test", "[result][monostate]")
 
 TEST_CASE("monostate failure test", "[result][monostate]")
 {
-  auto func = []() -> result</*defaulted monostate*/>
+  auto func = []() -> result<void, void>
   {
     if (false)
       return success<>();
@@ -722,7 +722,7 @@ TEST_CASE("monostate failure test", "[result][monostate]")
 
 TEST_CASE("contextually convertible to bool", "[result]")
 {
-  auto err_func = []() -> result</*defaulted monostate*/>
+  auto err_func = []() -> result<void, void>
   {
     if (false)
       return failure<>();
@@ -874,7 +874,7 @@ struct is_complete_type<T, std::void_t<decltype(sizeof(T))>> : std::true_type
 TEST_CASE("incomplete type reference", "[result]")
 {
   static_assert(!is_complete_type<incomplete_type>::value);
-  [[maybe_unused]] result<incomplete_type&> res =
+  [[maybe_unused]] result<incomplete_type&, void> res =
       success<incomplete_type&>(get_incomplete_type()
       ); // use incomplete_type& for result
 }
@@ -1496,8 +1496,8 @@ TEST_CASE("MITAMA_TRY2", "[result][mitama_try]")
 {
   (void)[]
   {
-    auto res =
-        mut_result<std::unique_ptr<u32>>{ mitama::in_place_ok, new auto(42u) };
+    auto res = mut_result<std::unique_ptr<u32>, void>{ mitama::in_place_ok,
+                                                       new auto(42u) };
 
     auto&& ret = MITAMA_TRY(std::move(res));
     return mitama::failure();


### PR DESCRIPTION
Leaving types for result out can be confusing.  For instance, it is difficult to read the meaning of result<> without knowing the actual implementation.  This probably comes from because std::monostate is the implementation details, but now that void is allowed, result<void, void> is clearer than result<>.