### PR TITLE
Tweak derive_error

### DIFF
--- a/docs/docs/thiserror/thiserror.md
+++ b/docs/docs/thiserror/thiserror.md
@@ -8,10 +8,7 @@ For example, if you want to write `data_store_error`, you can write the followin
 ```cpp
 #include <mitama/thiserror/thiserror.hpp>
 
-class data_store_error {
-  template <mitama::thiserror::fixed_string S, class ...T>
-  using error = mitama::thiserror::error<S, T...>;
-public:
+struct data_store_error : mitama::thiserror::derive_error {
   using disconnect
       = error<"data store disconnected">;
   using redaction
@@ -47,10 +44,7 @@ Examples:
 namespace anyhow = mitama::anyhow;
 using namespace std::literals;
 
-class data_store_error {
-  template <mitama::thiserror::fixed_string S, class ...T>
-  using error = mitama::thiserror::error<S, T...>;
-public:
+struct data_store_error : mitama::thiserror::derive_error {
   using disconnect
         = error<"data store disconnected">;
   using redaction

--- a/include/mitama/thiserror/thiserror.hpp
+++ b/include/mitama/thiserror/thiserror.hpp
@@ -88,8 +88,9 @@ public:
   }
 };
 
-struct derive_error
+class derive_error
 {
+protected:
   template <fixed_string Msg, class... Sources>
   using error = error<Msg, Sources...>;
 };

--- a/test/anyhow_tests.cpp
+++ b/test/anyhow_tests.cpp
@@ -49,9 +49,8 @@ TEST_CASE("try with context", "[anyhow][context]")
   std::cout << res << std::endl;
 }
 
-class data_store_error : mitama::thiserror::derive_error
+struct data_store_error : mitama::thiserror::derive_error
 {
-public:
   using disconnect = error<"data store disconnected">;
   using redaction = error<"for key `{0}` isn't available", std::string>;
   using invalid_header =


### PR DESCRIPTION
In the docs, data_store_error inherits derive_error instead of using error to avoid manually defining the error alias template.  In the derive_error implementation, it makes more sense to use protected for the error type as it is not meant to be used only by derived classes. Also, use class, not struct, as this is for inheritance.  On the userside context, data_store_error uses struct rather than class as it's just a container for error types.