### PR TITLE
RFC 1: fix incorrect maybe<bool>(maybe<U>) ctor call

### DIFF
--- a/test/maybe_tests.cpp
+++ b/test/maybe_tests.cpp
@@ -26,11 +26,27 @@ TEST_CASE("is_just()", "[maybe][is_just]")
 
 TEST_CASE("is_nothing()", "[maybe][is_nothing]")
 {
-  maybe<int> x = just(2);
-  REQUIRE_FALSE(x.is_nothing());
+  {
+    maybe<int> x = just(2);
+    REQUIRE_FALSE(x.is_nothing());
 
-  maybe<int> y = nothing;
-  REQUIRE(y.is_nothing());
+    maybe<int> y = nothing;
+    REQUIRE(y.is_nothing());
+  }
+  {
+    maybe<bool> x = nothing;
+    REQUIRE(x.is_nothing());
+
+    maybe<bool> y(x);
+    REQUIRE(y.is_nothing());
+  }
+  {
+    maybe<int> x = nothing;
+    REQUIRE(x.is_nothing());
+
+    maybe<bool> y(x); // implicit conversion
+    REQUIRE(y.is_nothing());
+  }
 }
 
 TEST_CASE("unwrap()", "[maybe][unwrap]")


### PR DESCRIPTION
When `maybe<bool>(maybe<U>)` is called, `maybe<U>` will be converted bool via operator bool(), which always results in `maybe<bool>.is_just()`. This is incorrect when `maybe<U>.is_nothing()`.

This patch adds an additional constructor to handle this case properly. The issue happened only without const/constexpr on `maybe<U>`, of which I still don't understand the reason.  To remove complexity and possible remaining bugs, I would recommend simply removing operator bool().

See also: #412 