### PR TITLE
Fix incorrect maybe<bool>(maybe<U>) ctor call

### DIFF
--- a/include/mitama/maybe/factory/just_nothing.hpp
+++ b/include/mitama/maybe/factory/just_nothing.hpp
@@ -189,14 +189,14 @@ public:
     requires meta::is_comparable_with<T, U>::value
   friend constexpr bool operator==(const maybe<U>& lhs, const just_t& rhs)
   {
-    return lhs && (lhs.unwrap() == rhs.get());
+    return lhs.is_just() && (lhs.unwrap() == rhs.get());
   }
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
   friend constexpr bool operator==(const just_t& lhs, const maybe<U>& rhs)
   {
-    return rhs && (lhs.get() == rhs.unwrap());
+    return rhs.is_just() && (lhs.get() == rhs.unwrap());
   }
 
   friend constexpr bool operator!=(const nothing_t, const just_t&)
@@ -251,14 +251,14 @@ public:
     requires meta::is_less_comparable_with<T, U>::value
   friend constexpr bool operator<(const just_t& lhs, const maybe<U>& rhs)
   {
-    return rhs ? lhs.get() < rhs.unwrap() : false;
+    return rhs.is_just() ? lhs.get() < rhs.unwrap() : false;
   }
 
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
   friend constexpr bool operator<(const maybe<U>& lhs, const just_t& rhs)
   {
-    return lhs ? lhs.unwrap() < rhs.get() : true;
+    return lhs.is_just() ? lhs.unwrap() < rhs.get() : true;
   }
 
   friend constexpr bool operator<=(const nothing_t, const just_t&)
@@ -284,7 +284,8 @@ public:
              && meta::is_comparable_with<T, U>::value
   friend constexpr bool operator<=(const just_t& lhs, const maybe<U>& rhs)
   {
-    return rhs ? (lhs.get() < rhs.unwrap() || lhs.get() == rhs.unwrap())
+    return rhs.is_just()
+               ? (lhs.get() < rhs.unwrap() || lhs.get() == rhs.unwrap())
                : false;
   }
 
@@ -293,7 +294,9 @@ public:
              && meta::is_comparable_with<T, U>::value
   friend constexpr bool operator<=(const maybe<U>& lhs, const just_t& rhs)
   {
-    return lhs ? (lhs.unwrap() < rhs.get() || lhs.unwrap() == rhs.get()) : true;
+    return lhs.is_just()
+               ? (lhs.unwrap() < rhs.get() || lhs.unwrap() == rhs.get())
+               : true;
   }
 
   friend constexpr bool operator>(const nothing_t, const just_t&)
@@ -429,14 +432,14 @@ public:
     requires meta::is_comparable_with<T, U>::value
   friend constexpr bool operator==(const maybe<U>& lhs, const just_t& rhs)
   {
-    return lhs && (lhs.unwrap() == rhs.get());
+    return lhs.is_just() && (lhs.unwrap() == rhs.get());
   }
 
   template <class U>
     requires meta::is_comparable_with<T, U>::value
   friend constexpr bool operator==(const just_t& lhs, const maybe<U>& rhs)
   {
-    return rhs && (lhs.get() == rhs.unwrap());
+    return rhs.is_just() && (lhs.get() == rhs.unwrap());
   }
 
   friend constexpr bool operator!=(const nothing_t, const just_t&)
@@ -491,14 +494,14 @@ public:
     requires meta::is_less_comparable_with<T, U>::value
   friend constexpr bool operator<(const just_t& lhs, const maybe<U>& rhs)
   {
-    return rhs ? lhs.get() < rhs.unwrap() : false;
+    return rhs.is_just() ? lhs.get() < rhs.unwrap() : false;
   }
 
   template <class U>
     requires meta::is_less_comparable_with<T, U>::value
   friend constexpr bool operator<(const maybe<U>& lhs, const just_t& rhs)
   {
-    return lhs ? lhs.unwrap() < rhs.get() : true;
+    return lhs.is_just() ? lhs.unwrap() < rhs.get() : true;
   }
 
   friend constexpr bool operator<=(const nothing_t, const just_t&)
@@ -524,7 +527,8 @@ public:
              && meta::is_comparable_with<T, U>::value
   friend constexpr bool operator<=(const just_t& lhs, const maybe<U>& rhs)
   {
-    return rhs ? (lhs.get() < rhs.unwrap() || lhs.get() == rhs.unwrap())
+    return rhs.is_just()
+               ? (lhs.get() < rhs.unwrap() || lhs.get() == rhs.unwrap())
                : false;
   }
 
@@ -533,7 +537,9 @@ public:
              && meta::is_comparable_with<T, U>::value
   friend constexpr bool operator<=(const maybe<U>& lhs, const just_t& rhs)
   {
-    return lhs ? (lhs.unwrap() < rhs.get() || lhs.unwrap() == rhs.get()) : true;
+    return lhs.is_just()
+               ? (lhs.unwrap() < rhs.get() || lhs.unwrap() == rhs.get())
+               : true;
   }
 
   friend constexpr bool operator>(const nothing_t, const just_t&)

--- a/include/mitama/maybe/maybe.hpp
+++ b/include/mitama/maybe/maybe.hpp
@@ -330,11 +330,6 @@ public:
   {
   }
 
-  explicit constexpr operator bool() const
-  {
-    return is_just();
-  }
-
   constexpr value_type* operator->() &
   {
     return &(std::get<just_t<T>>(storage_).get());

--- a/include/mitama/result/detail/result_impl.hpp
+++ b/include/mitama/result/detail/result_impl.hpp
@@ -81,7 +81,8 @@ public:
     {
       if (const auto& may =
               static_cast<const basic_result<_mutability, maybe<T>, E>*>(this)
-                  ->unwrap())
+                  ->unwrap();
+          may.is_just())
       {
         return maybe<basic_result<_mutability, T, E>>{ std::in_place,
                                                        in_place_ok,

--- a/test/maybe_tests.cpp
+++ b/test/maybe_tests.cpp
@@ -26,11 +26,21 @@ TEST_CASE("is_just()", "[maybe][is_just]")
 
 TEST_CASE("is_nothing()", "[maybe][is_nothing]")
 {
-  maybe<int> x = just(2);
-  REQUIRE_FALSE(x.is_nothing());
+  {
+    maybe<int> x = just(2);
+    REQUIRE_FALSE(x.is_nothing());
 
-  maybe<int> y = nothing;
-  REQUIRE(y.is_nothing());
+    maybe<int> y = nothing;
+    REQUIRE(y.is_nothing());
+  }
+  {
+    maybe<bool> x = nothing;
+    REQUIRE(x.is_nothing());
+
+    // Issue #412
+    maybe<bool> y(x);
+    REQUIRE(y.is_nothing());
+  }
 }
 
 TEST_CASE("unwrap()", "[maybe][unwrap]")


### PR DESCRIPTION
When `maybe<bool>(maybe<U>)` is called, `maybe<U>` will be converted bool via operator bool(), which always results in `maybe<bool>.is_just()`. This is incorrect when `maybe<U>.is_nothing()`.

This patch removes the operator bool() implementation to avoid this unintentional implicit conversion.

See also: #411