### PR TITLE
Rename success & failure to ok & err

### DIFF
--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -80,13 +80,13 @@ Rewrite this code using result.
 ```cpp
 auto func(int a) -> mitama::result<int, std::string> {
   if ( first check )
-    return mitama::failure("first check failed"); // early return
+    return mitama::err("first check failed"); // early return
   if ( second check )
-    return mitama::failure("second check failed"); // early return
+    return mitama::err("second check failed"); // early return
   if ( third check )
-    return mitama::failure("third check failed"); // early return
+    return mitama::err("third check failed"); // early return
   // function body...
-  return mitama::success(42);
+  return mitama::ok(42);
 }
 // ...
 int value = func(42).unwrap();

--- a/docs/docs/anyhow/anyhow.md
+++ b/docs/docs/anyhow/anyhow.md
@@ -27,13 +27,13 @@ In the first example, we replace `mitama::result` with `anyhow::result`.
 namespace anyhow = mitama::anyhow;
 
 int main() {
-  anyhow::result<int> res = mitama::success(1);
+  anyhow::result<int> res = mitama::ok(1);
 }
 ```
 
-In the second example, we make a error with `anyhow::anyhow`.
+In the second example, we make an error with `anyhow::anyhow`.
 `anyhow::anyhow` creates `std::shared_ptr<anyhow::cause<T>>` from a given argument type of `T`.
-An expression `mitama::failure(anyhow::anyhow("error "s))` can be converted to `anyhow::result` since `anyhow::cause` inherits from `anyhow::error`.
+An expression `mitama::err(anyhow::anyhow("error "s))` can be converted to `anyhow::result` since `anyhow::cause` inherits from `anyhow::error`.
 
 ```cpp
 // begin example
@@ -44,7 +44,7 @@ namespace anyhow = mitama::anyhow;
 using namespace std::literals::string_literals;
 
 int main() {
-  anyhow::result<int> res = mitama::failure(anyhow::anyhow("error"s));
+  anyhow::result<int> res = mitama::err(anyhow::anyhow("error"s));
 }
 ```
 
@@ -87,7 +87,7 @@ using namespace std::literals::string_literals;
 struct database_t {}; // dummy
 
 auto connect_to_db() -> anyhow::result<database_t> {
-  return mitama::failure(anyhow::anyhow("Failed to connect to the database."s));
+  return mitama::err(anyhow::anyhow("Failed to connect to the database."s));
 }
 
 auto read_db() -> anyhow::result<int> {
@@ -105,6 +105,6 @@ int main() {
   
   std::cout << res << std::endl;
   // outputs:
-  // failure(cause: Failed to read the database. source: Failed to connect to the database.)
+  // err(cause: Failed to read the database. source: Failed to connect to the database.)
 }
 ```

--- a/docs/docs/maybe/APIs.md
+++ b/docs/docs/maybe/APIs.md
@@ -450,7 +450,7 @@ int main() {
 
 !!! summary "maybe&lt;T&gt; --> E [default=std::monostate] --> result&lt;T, E&gt;"
 
-    Transforms the `maybe<T>` into a `result<T, E>`, mapping `just(v)` to `success(v)` and `nothing` to `failure(err)`.
+    Transforms the `maybe<T>` into a `result<T, E>`, mapping `just(v)` to `ok(v)` and `nothing` to `err(e)`.
 
     Arguments passed to ok_or are eagerly evaluated; if you are passing the result of a function call, it is recommended to use ok_or_else, which is lazily evaluated.
 
@@ -479,11 +479,11 @@ using namespace std::string_literals;
 
 int main() {
   maybe x = just("foo"s);
-  assert(x.ok_or(0) == success("foo"s));
+  assert(x.ok_or(0) == ok("foo"s));
 
   maybe<std::string> y = nothing;
-  assert(y.ok_or(0) == failure(0));
-  assert(y.ok_or() == failure<>());
+  assert(y.ok_or(0) == err(0));
+  assert(y.ok_or() == err<>());
 }
 // end example
 ```
@@ -492,7 +492,7 @@ int main() {
 
 !!! summary "maybe&lt;T&gt; --> F --> result&lt;T, E&gt;"
 
-    Transforms the `maybe<T>` into a `result<T, E>`, mapping `just(v)` to `success(v)` and `nothing` to `failure(err())`.
+    Transforms the `maybe<T>` into a `result<T, E>`, mapping `just(v)` to `ok(v)` and `nothing` to `err(err())`.
 
 
 !!! note "constraints"
@@ -530,10 +530,10 @@ using namespace std::string_literals;
 
 int main() {
   maybe x = just("foo"s);
-  assert(x.ok_or_else([]{ return 0; }) == success("foo"s));
+  assert(x.ok_or_else([]{ return 0; }) == ok("foo"s));
 
   maybe<std::string> y = nothing;
-  assert(y.ok_or_else([]{ return 0; }) == failure(0));
+  assert(y.ok_or_else([]{ return 0; }) == err(0));
 }
 // end example
 ```
@@ -1093,8 +1093,8 @@ int main() {
 
     Transposes a `maybe` of a `result` into a `result` of a `maybe`.
 
-    `nothing` will be mapped to `success(nothing)`.
-    `just(success(_))` and `just(failure(_))` will be mapped to `success(just(_))` and `failure(_)`　(_ is a placeholder).
+    `nothing` will be mapped to `ok(nothing)`.
+    `just(ok(_))` and `just(err(_))` will be mapped to `ok(just(_))` and `err(_)`　(_ is a placeholder).
 
 !!! info "declarations"
 
@@ -1119,8 +1119,8 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-  result<maybe<int>, std::string> x = success(just(5));
-  maybe<result<int, std::string>> y = just(success(5));
+  result<maybe<int>, std::string> x = ok(just(5));
+  maybe<result<int, std::string>> y = just(ok(5));
   assert(x == y.transpose());
 }
 // end example

--- a/docs/docs/result/APIs.md
+++ b/docs/docs/result/APIs.md
@@ -4,7 +4,7 @@
 
 !!! summary "basic_result&lt;_, T, E&gt; --> bool"
 
-    Returns true if the result is `success`.
+    Returns true if the result is `ok`.
 
 
 !!! info "declarations"
@@ -28,9 +28,9 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-    result<unsigned, std::string> x = success(3);
+    result<unsigned, std::string> x = ok(3);
     assert(x.is_ok() == true);
-    result<unsigned, std::string> y = failure("Some error message"s);
+    result<unsigned, std::string> y = err("Some error message"s);
     assert(y.is_ok() == false);
 }
 // end example
@@ -40,7 +40,7 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> bool"
 
-    Returns true if the result is failure.
+    Returns true if the result is err.
 
 
 !!! info "declarations"
@@ -64,10 +64,10 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-    result<unsigned, std::string> x = success(3);
+    result<unsigned, std::string> x = ok(3);
     assert(x.is_err() == false);
 
-    result<unsigned, std::string> y = failure("Some error message"s);
+    result<unsigned, std::string> y = err("Some error message"s);
     assert(y.is_err() == true);
 }
 // end example
@@ -79,7 +79,7 @@ int main() {
 
     Converts from `basic_result` to `maybe`.
 
-    Converts self into a `maybe`, and discarding the failure value, if any.
+    Converts self into a `maybe`, and discarding the err value, if any.
 
     Note that these functions propagate mutability to element type of `maybe`.
 
@@ -130,9 +130,9 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-    result<unsigned, std::string> x = success(2);
+    result<unsigned, std::string> x = ok(2);
     assert(x.ok() == just(2));
-    result<unsigned, std::string> y = failure("Nothing here"s);
+    result<unsigned, std::string> y = err("Nothing here"s);
     assert(y.ok() == nothing);
 }
 // end example
@@ -145,7 +145,7 @@ int main() {
 
     Converts from `basic_result` to `maybe`.
 
-    Converts self into a `maybe`, and discarding the success value, if any.
+    Converts self into a `maybe`, and discarding the ok value, if any.
 
     Note that these functions propagate mutability to element type of `maybe`.
 
@@ -196,9 +196,9 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-    result<unsigned, std::string> x = success(2);
+    result<unsigned, std::string> x = ok(2);
     assert(x.err() == nothing);
-    result<unsigned, std::string> y = failure("Nothing here"s);
+    result<unsigned, std::string> y = err("Nothing here"s);
     assert(y.err() == just("Nothing here"s));
 }
 // end example
@@ -209,7 +209,7 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> O --> basic_result&lt;_, U, E&gt;"
 
-    Maps a `result<T, E>` to `result<U, E>` by applying a function to a contained `success` value, leaving an `failure` value untouched.
+    Maps a `result<T, E>` to `result<U, E>` by applying a function to a contained `ok` value, leaving an `err` value untouched.
 
     This function can be used to compose the results of two functions.
 
@@ -243,11 +243,11 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-    result<int, int> ok = success(2);
-    assert(ok.map([](int x) { return x * 2; }) == success(4));
+    result<int, int> o = ok(2);
+    assert(o.map([](int x) { return x * 2; }) == ok(4));
 
-    result<int, int> err = failure(2);
-    assert(err.map([](int x) { return x * 2; }) == failure(2));
+    result<int, int> e = err(2);
+    assert(e.map([](int x) { return x * 2; }) == err(2));
 }
 // end example
 ```
@@ -257,9 +257,9 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> Fallback --> Map --> U, <br>where Fallback: E --> U, Map: T --> U"
 
-    Maps a `result<T, E>` to `U` by applying a function to a contained `success` value, or a fallback function to a contained `failure` value.
+    Maps a `result<T, E>` to `U` by applying a function to a contained `ok` value, or a fallback function to a contained `err` value.
 
-    This function can be used to unpack a successful result while handling an error.
+    This function can be used to unpack an ok result while handling an error.
 
 
 !!! note "constraints"
@@ -298,11 +298,11 @@ using namespace std::string_literals;
 int main() {
     auto k = 21;
     {
-        result<std::string, std::string> x = success("foo"s);
+        result<std::string, std::string> x = ok("foo"s);
         assert(x.map_or_else([k](auto){ return k * 2; }, [](auto v) { return v.length(); }) == 3);
     }
     {
-        result<std::string, std::string> x = failure("bar"s);
+        result<std::string, std::string> x = err("bar"s);
         assert(x.map_or_else([k](auto){ return k * 2; }, [](auto v) { return v.length(); }) == 42);
     }
 }
@@ -314,7 +314,7 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> Map --> U, <br>where<br>&ensp;Map: T --> U,<br>&ensp;Map: E --> U"
 
-    Maps a `result<T, E>` to `U` by applying a function `_map` to a contained either `success` or `failure` value.
+    Maps a `result<T, E>` to `U` by applying a function `_map` to a contained either `ok` or `err` value.
 
     This function is syntax sugar for `res.map_or_else(_map, _map)`.
 
@@ -357,11 +357,11 @@ using namespace std::string_literals;
 
 int main() {
     {
-        result<std::string, std::string> x = success("foo"s);
+        result<std::string, std::string> x = ok("foo"s);
         assert(x.map_anything_else([](auto v) { return v.length(); }) == 3);
     }
     {
-        result<std::string, std::string> x = failure("bar"s);
+        result<std::string, std::string> x = err("bar"s);
         assert(x.map_anything_else([](auto v) { return v.length(); }) == 3);
     }
 }
@@ -373,9 +373,9 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> O --> basic_result&lt;_, T, F&gt; <br>where O: E -> F"
 
-    Maps a `result<T, E>` to `result<T, F>` by applying a function to a contained failure value, leaving an success value untouched.
+    Maps a `result<T, E>` to `result<T, F>` by applying a function to a contained err value, leaving an ok value untouched.
 
-    This function can be used to pass through a successful result while handling an error.
+    This function can be used to pass through an ok result while handling an error.
 
 
 !!! note "constraints"
@@ -413,10 +413,10 @@ int main() {
     auto stringify = [](unsigned x) -> std::string{
         return "error code: "s + std::to_string(x);
     };
-    result<unsigned, unsigned> x = success(2);
-    assert(x.map_err(stringify) == success(2u));
-    result<unsigned, unsigned> y = failure(13);
-    assert(y.map_err(stringify) == failure("error code: 13"s));
+    result<unsigned, unsigned> x = ok(2);
+    assert(x.map_err(stringify) == ok(2u));
+    result<unsigned, unsigned> y = err(13);
+    assert(y.map_err(stringify) == err("error code: 13"s));
 }
 // end example
 ```
@@ -426,7 +426,7 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> basic_result&lt;_, U, E&gt; --> basic_result&lt;_, U, E&gt;"
 
-    `self.conj(res)` returns `res` if the result is `success`, otherwise returns the `failure` value of self.
+    `self.conj(res)` returns `res` if the result is `ok`, otherwise returns the `err` value of self.
 
 !!! info "declarations"
 
@@ -456,24 +456,24 @@ using namespace std::string_literals;
 
 int main() {
     {
-        result<unsigned, std::string> x = success(2);
-        result<std::string, std::string> y = failure("late error"s);
-        assert((x && y) == failure("late error"s));
+        result<unsigned, std::string> x = ok(2);
+        result<std::string, std::string> y = err("late error"s);
+        assert((x && y) == err("late error"s));
     }
     {
-        result<unsigned, std::string> x = failure("early error"s);
-        result<std::string, std::string> y = success("foo"s);
-        assert((x && y) == failure("early error"s));
+        result<unsigned, std::string> x = err("early error"s);
+        result<std::string, std::string> y = ok("foo"s);
+        assert((x && y) == err("early error"s));
     }
     {
-        result<unsigned, std::string> x = failure("not a 2"s);
-        result<std::string, std::string> y = failure("late error"s);
-        assert((x && y) == failure("not a 2"s));
+        result<unsigned, std::string> x = err("not a 2"s);
+        result<std::string, std::string> y = err("late error"s);
+        assert((x && y) == err("not a 2"s));
     }
     {
-        result<unsigned, std::string> x = success(2);
-        result<std::string, std::string> y = success("different result type"s);
-        assert((x && y) == success("different result type"s));
+        result<unsigned, std::string> x = ok(2);
+        result<std::string, std::string> y = ok("different result type"s);
+        assert((x && y) == ok("different result type"s));
     }
 }
 // end example
@@ -483,7 +483,7 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> O --> basic_result&lt;_, U, E&gt;, <br>where O: T --> basic_result&lt;_, U, E&gt;"
 
-    `self.and_then(op)` calls `op` if the result is success, otherwise returns the failure value of self.
+    `self.and_then(op)` calls `op` if the result is ok, otherwise returns the err value of self.
 
     This function can be used for control flow based on result values.
 
@@ -503,17 +503,17 @@ int main() {
         template <class O,
             std::enable_of>
         constexpr auto and_then(O&& op) &
-            -> std::enable_if_t<is_convertible_result_with_v<std::invoke_result_t<O&&, T&>, failure<E>>,
+            -> std::enable_if_t<is_convertible_result_with_v<std::invoke_result_t<O&&, T&>, err_t<E>>,
             std::invoke_result_t<O, T>> ;
 
         template <class O>
         constexpr auto and_then(O&& op) const&
-            -> std::enable_if_t<is_convertible_result_with_v<std::invoke_result_t<O&&, T const&>, failure<E>>,
+            -> std::enable_if_t<is_convertible_result_with_v<std::invoke_result_t<O&&, T const&>, err_t<E>>,
             std::invoke_result_t<O, T>> ;
 
         template <class O>
         constexpr auto and_then(O&& op) &&
-            -> std::enable_if_t<is_convertible_result_with_v<std::invoke_result_t<O&&, T&&>, failure<E>>,
+            -> std::enable_if_t<is_convertible_result_with_v<std::invoke_result_t<O&&, T&&>, err_t<E>>,
             std::invoke_result_t<O, T>> ;
     };
     ```
@@ -530,16 +530,16 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-    auto sq = [](unsigned x) -> result<unsigned, unsigned> { return success(x * x); };
-    auto err = [](unsigned x) -> result<unsigned, unsigned> { return failure(x); };
+    auto sq = [](unsigned x) -> result<unsigned, unsigned> { return ok(x * x); };
+    auto er = [](unsigned x) -> result<unsigned, unsigned> { return err(x); };
 
-    result<int, int> x = success(2u);
-    result<int, int> y = failure(3u);
+    result<int, int> x = ok(2u);
+    result<int, int> y = err(3u);
 
-    assert(x.and_then(sq).and_then(sq) == success(16u));
-    assert(x.and_then(sq).and_then(err) == failure(4u));
-    assert(x.and_then(err).and_then(sq) == failure(2u));
-    assert(y.and_then(sq).and_then(sq) == failure(3u));
+    assert(x.and_then(sq).and_then(sq) == ok(16u));
+    assert(x.and_then(sq).and_then(er) == err(4u));
+    assert(x.and_then(er).and_then(sq) == err(2u));
+    assert(y.and_then(sq).and_then(sq) == err(3u));
 }
 // end example
 ```
@@ -548,7 +548,7 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> basic_result&lt;_, T, F&gt; --> basic_result&lt;_, T, F&gt;"
 
-    `self.disj(res)` returns `res` if the result is `failure`, otherwise returns the `success` value of self.
+    `self.disj(res)` returns `res` if the result is `err`, otherwise returns the `ok` value of self.
 
     Arguments passed to or are eagerly evaluated; if you are passing the result of a function call, it is recommended to use `or_else`, which is lazily evaluated.
 
@@ -581,28 +581,28 @@ using namespace std::string_literals;
 
 int main() {
     {
-        result<unsigned, std::string> x = success(2);
-        result<unsigned, std::string> y = failure("late error"s);
-        assert(x.disj(y) ==  success(2u));
-        assert((x || y) ==  success(2u));
+        result<unsigned, std::string> x = ok(2);
+        result<unsigned, std::string> y = err("late error"s);
+        assert(x.disj(y) ==  ok(2u));
+        assert((x || y) ==  ok(2u));
     }
     {
-        result<unsigned, std::string> x = failure("early error"s);
-        result<unsigned, std::string> y = success(2);
-        assert(x.disj(y) ==  success(2u));
-        assert((x || y) ==  success(2u));
+        result<unsigned, std::string> x = err("early error"s);
+        result<unsigned, std::string> y = ok(2);
+        assert(x.disj(y) ==  ok(2u));
+        assert((x || y) ==  ok(2u));
     }
     {
-        result<unsigned, std::string> x = failure("not a 2"s);
-        result<unsigned, std::string> y = failure("late error"s);
-        assert(x.disj(y) ==  failure("late error"s));
-        assert((x || y) ==  failure("late error"s));
+        result<unsigned, std::string> x = err("not a 2"s);
+        result<unsigned, std::string> y = err("late error"s);
+        assert(x.disj(y) ==  err("late error"s));
+        assert((x || y) ==  err("late error"s));
     }
     {
-        result<unsigned, std::string> x = success(2);
-        result<unsigned, std::string> y = success(100);
-        assert(x.disj(y) ==  success(2u));
-        assert((x || y) ==  success(2u));
+        result<unsigned, std::string> x = ok(2);
+        result<unsigned, std::string> y = ok(100);
+        assert(x.disj(y) ==  ok(2u));
+        assert((x || y) ==  ok(2u));
     }
 }
 // end example
@@ -613,7 +613,7 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> O --> basic_result&lt;_, T, F&gt;, <br>where O: E -> basic_result&lt;_, T, F&gt;"
 
-    `self.or_else(op)` calls `op` if the result is `failure`, otherwise returns the `success` value of self.
+    `self.or_else(op)` calls `op` if the result is `err`, otherwise returns the `ok` value of self.
 
     This function can be used for control flow based on result values.
 
@@ -649,16 +649,16 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-    auto sq = [](unsigned x) -> result<unsigned, unsigned> { return success(x * x); };
-    auto err = [](unsigned x) -> result<unsigned, unsigned> { return failure(x); };
+    auto sq = [](unsigned x) -> result<unsigned, unsigned> { return ok(x * x); };
+    auto er = [](unsigned x) -> result<unsigned, unsigned> { return err(x); };
 
-    result<int, int> x = success(2u);
-    result<int, int> y = failure(3u);
+    result<int, int> x = ok(2u);
+    result<int, int> y = err(3u);
 
-    assert(x.or_else(sq).or_else(sq) == success(2u));
-    assert(x.or_else(err).or_else(sq) == success(2u));
-    assert(y.or_else(sq).or_else(err) == success(9u));
-    assert(y.or_else(err).or_else(err) == failure(3u));
+    assert(x.or_else(sq).or_else(sq) == ok(2u));
+    assert(x.or_else(er).or_else(sq) == ok(2u));
+    assert(y.or_else(sq).or_else(er) == ok(9u));
+    assert(y.or_else(er).or_else(er) == err(3u));
 }
 // end example
 ```
@@ -668,7 +668,7 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> T const& --> T"
 
-    `self.unwrap_or(optb)` unwraps a result, yielding the content of an `success`. Else, it returns `optb`.
+    `self.unwrap_or(optb)` unwraps a result, yielding the content of an `ok`. Else, it returns `optb`.
 
     Arguments passed to unwrap_or are eagerly evaluated; if you are passing the result of a function call, it is recommended to use `unwrap_or_else`, which is lazily evaluated.
 
@@ -694,10 +694,10 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-    result<unsigned, unsigned> ok = success(2);
-    result<unsigned, unsigned> err = failure(2);
-    assert(ok.unwrap_or(1u) == 2u);
-    assert(err.unwrap_or(1u) == 1u);
+    result<unsigned, unsigned> o = ok(2);
+    result<unsigned, unsigned> e = err(2);
+    assert(o.unwrap_or(1u) == 2u);
+    assert(e.unwrap_or(1u) == 1u);
 }
 // end example
 ```
@@ -706,7 +706,7 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> O --> T, <br>where O: E --> T"
 
-    `self.unwrap_or_else(op)` unwraps a result, yielding the content of an `success`. If the value is an `failure` then it invokes `op` with its value.
+    `self.unwrap_or_else(op)` unwraps a result, yielding the content of an `ok`. If the value is an `err` then it invokes `op` with its value.
 
 
 !!! ntoe "constraints"
@@ -741,10 +741,10 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-    result<int, std::string> ok = success(2);
-    result<int, std::string> err = failure("foo"s);
-    assert(ok.unwrap_or_else(&std::string::size) == 2);
-    assert(err.unwrap_or_else(&std::string::size) == 3);
+    result<int, std::string> o = ok(2);
+    result<int, std::string> e = err("foo"s);
+    assert(o.unwrap_or_else(&std::string::size) == 2);
+    assert(e.unwrap_or_else(&std::string::size) == 3);
 }
 // end example
 ```
@@ -753,12 +753,12 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> E"
 
-    Unwraps a result, yielding the content of an `success`.
+    Unwraps a result, yielding the content of an `ok`.
 
 
 !!! warning "exceptions"
 
-    Raise `mitama::runtime_panic` if a result is containing `failure` value.
+    Raise `mitama::runtime_panic` if a result is containing `err` value.
 
 
 !!! hint "remarks"
@@ -802,12 +802,12 @@ using namespace std::string_literals;
 
 int main() {
     {
-        result<unsigned, std::string> x = success(2);
+        result<unsigned, std::string> x = ok(2);
         assert(x.unwrap() == 2);
     }
     try {
-        result<unsigned, std::string> x = failure("emergency failure"s);
-        x.unwrap(); // panics with `emergency failure`
+        result<unsigned, std::string> x = err("emergency error"s);
+        x.unwrap(); // panics with `emergency error`
     }
     catch ( mitama::runtime_panic const& panic ) {
         std::cerr << panic.what() << std::endl;
@@ -820,12 +820,12 @@ int main() {
 
 !!! summary "basic_result&lt;_, T, E&gt; --> E"
 
-    Unwraps a result, yielding the content of an `failure`.
+    Unwraps a result, yielding the content of an `err`.
 
 
 !!! warning "exceptions"
 
-    Raise `mitama::runtime_panic` if a result is containing `success` value.
+    Raise `mitama::runtime_panic` if a result is containing `ok` value.
 
 
 !!! hint "remarks"
@@ -869,7 +869,7 @@ using namespace std::string_literals;
 
 int main() {
     try {
-        result<unsigned, std::string> x = success(2);
+        result<unsigned, std::string> x = ok(2);
         x.unwrap_err(); // panics with `2`
     }
     catch (runtime_panic const &panic)
@@ -877,8 +877,8 @@ int main() {
         std::cerr << panic.what() << std::endl;
     }
     {
-        result<unsigned, std::string> x = failure("emergency failure"s);
-        assert(x.unwrap_err() == "emergency failure"s);
+        result<unsigned, std::string> x = err("emergency error"s);
+        assert(x.unwrap_err() == "emergency error"s);
     }
 }
 // end example
@@ -891,7 +891,7 @@ int main() {
 
     Returns the contained value or a default.
 
-    If `success`, returns the contained value, otherwise if `failure`, returns the default value for that type.
+    If `ok`, returns the contained value, otherwise if `err`, returns the default value for that type.
 
 
 !!! note "constraints"
@@ -927,8 +927,8 @@ using namespace mitama;
 using namespace std::string_literals;
 
 int main() {
-    result<int, void> good = success(1909);
-    result<int, void> bad = failure<>();
+    result<int, void> good = ok(1909);
+    result<int, void> bad = err<>();
     auto good_year = good.unwrap_or_default();
     auto bad_year = bad.unwrap_or_default();
     assert(1909 == good_year);
@@ -944,8 +944,8 @@ int main() {
 
     Transposes a `result` of a `maybe` into a `maybe` of a `result`.
 
-    `success(nothing)` will be mapped to `nothing`.
-    `success(just(v))` and `failure(v)` will be mapped to `just(success(v))` and `just(failure(v))`.
+    `ok(nothing)` will be mapped to `nothing`.
+    `ok(just(v))` and `err(v)` will be mapped to `just(ok(v))` and `just(err(v))`.
 
 !!! info "declarations"
 
@@ -971,8 +971,8 @@ int main() {
 using namespace mitama;
 
 int main() {
-    result<maybe<int>, std::string> x = success(just(5));
-    maybe<result<int, std::string>> y = just(success(5));
+    result<maybe<int>, std::string> x = ok(just(5));
+    maybe<result<int, std::string>> y = just(ok(5));
     assert(x.transpose() == y);
 }
 // end example
@@ -983,7 +983,7 @@ int main() {
 
 !!! summary "basic_result&lt;T, E&gt; --> F --> void"
 
-    Invokes the provided function with the contained success value (if success), or doing nothing (if failure).
+    Invokes the provided function with the contained ok value (if ok), or doing nothing (if err).
     The return value of F will be discarded whether void or not.
 
 
@@ -1009,7 +1009,7 @@ int main() {
 using namespace mitama;
 
 int main() {
-  result<int, std::string> x = success(42);
+  result<int, std::string> x = ok(42);
   int hook = 0;
   x.and_finally([&](int const& v){ hook = v; });
   assert(hook == 42);
@@ -1022,7 +1022,7 @@ int main() {
 
 !!! summary "basic_result&lt;T, E&gt; --> F --> void"
 
-    Invokes the provided function with contained failure value (if failure), or doing nothing (if success).
+    Invokes the provided function with contained err value (if err), or doing nothing (if ok).
     The return value of F will be discarded whether void or not.
 
 
@@ -1052,7 +1052,7 @@ int main() {
     using namespace std::literals;
 
     std::string hook = "default";
-    result<int, std::string> x = success(42);
+    result<int, std::string> x = ok(42);
 
     x.or_finally([&hook](std::string v){
         hook = v;
@@ -1060,7 +1060,7 @@ int main() {
 
     assert(hook == "default"s);
 
-    result<int, std::string> y = failure("error"s);
+    result<int, std::string> y = err("error"s);
 
     y.or_finally([&hook](std::string v){
         hook = v;
@@ -1076,9 +1076,9 @@ int main() {
 
 !!! summary "basic_result&lt;T, E&gt; --> F --> basic_result&lt;T, E&gt;"
 
-    Peeks the contained success value and then returns self.
+    Peeks the contained ok value and then returns self.
 
-    Invokes the provided function with the contained value and then return self (if success), or return self without doing anything (if failure).
+    Invokes the provided function with the contained value and then return self (if ok), or return self without doing anything (if err).
 
 
 !!! info "declarations"
@@ -1107,9 +1107,9 @@ int main() {
 using namespace mitama;
 
 int main() {
-    result<int, std::string> x = success(42);
+    result<int, std::string> x = ok(42);
     int hook = 0;
-    assert(x.and_peek([&](int const& v){ hook = v; }) == success(42));
+    assert(x.and_peek([&](int const& v){ hook = v; }) == ok(42));
     assert(hook == 42);
 }
 // end example
@@ -1120,9 +1120,9 @@ int main() {
 
 !!! summary "basic_result&lt;T, E&gt; --> F --> basic_result&lt;T, E&gt;"
 
-    Peeks the contained failure value and then returns self.
+    Peeks the contained err value and then returns self.
 
-    Invokes the provided function and then return self (if failure), or return self without doing anything (if success).
+    Invokes the provided function and then return self (if err), or return self without doing anything (if ok).
 
 
 !!! info "declarations"

--- a/docs/docs/result/comparisons.md
+++ b/docs/docs/result/comparisons.md
@@ -22,80 +22,80 @@ template< class T, class E, class U, class F >
 constexpr bool operator>=( const basic_result<T, E>& lhs,
                            const basic_result<U, F>& rhs ); // (6)
 
-// Compare a basic_result object with a success(value)
+// Compare a basic_result object with an ok(value)
 template< class T, class E, class U >
 constexpr bool operator==( const basic_result<T, E>& res,
-                           success<U> const& ok );          // (7)
+                           ok_t<U> const& ok );          // (7)
 template< class T, class E, class U >
-constexpr bool operator==( success<T> const& ok,
+constexpr bool operator==( ok_t<T> const& ok,
                            const basic_result<U, E>& res ); // (8)
 template< class T, class E, class U >
 constexpr bool operator!=( const basic_result<T, E>& res,
-                           success<U> const& ok );          // (9)
+                           ok_t<U> const& ok );          // (9)
 template< class T, class E, class U >
-constexpr bool operator!=( success<T> const& ok,
+constexpr bool operator!=( ok_t<T> const& ok,
                            const basic_result<U, E>& res ); // (10)
 template< class T, class E, class U >
 constexpr bool operator<( const basic_result<T, E>& res,
-                          success<U> const& ok );           // (11)
+                          ok_t<U> const& ok );           // (11)
 template< class T, class E, class U >
-constexpr bool operator<( success<T> const& ok,
+constexpr bool operator<( ok_t<T> const& ok,
                           const basic_result<U, E>& res );  // (12)
 template< class T, class E, class U >
 constexpr bool operator<=( const basic_result<T, E>& res,
-                           success<U> const& ok );          // (13)
+                           ok_t<U> const& ok );          // (13)
 template< class T, class E, class U >
-constexpr bool operator<=( success<T> const& ok,
+constexpr bool operator<=( ok_t<T> const& ok,
                            const basic_result<U, E>& res ); // (14)
 template< class T, class E, class U >
 constexpr bool operator>( const basic_result<T, E>& res,
-                          success<U> const& ok );           // (15)
+                          ok_t<U> const& ok );           // (15)
 template< class T, class E, class U >
-constexpr bool operator>( success<T> const& ok,
+constexpr bool operator>( ok_t<T> const& ok,
                           const basic_result<U, E>& res );  // (16)
 template< class T, class E, class U >
 constexpr bool operator>=( const basic_result<T, E>& res,
-                           success<U> const& ok );          // (17)
+                           ok_t<U> const& ok );          // (17)
 template< class T, class E, class U >
-constexpr bool operator>=( success<T> const& ok, 
+constexpr bool operator>=( ok_t<T> const& ok,
                            const basic_result<U, E>& res ); // (18)
 
-// Compare a basic_result object with a failure(value)
+// Compare a basic_result object with an err(value)
 template< class T, class E, class F >
 constexpr bool operator==( const basic_result<T, E>& res,
-                           failure<F> const& err );         // (19)
+                           err_t<F> const& err );         // (19)
 template< class T, class E, class U >
-constexpr bool operator==( failure<E> const& err,
+constexpr bool operator==( err_t<E> const& err,
                            const basic_result<T, F>& res ); // (20)
 template< class T, class E, class U >
 constexpr bool operator!=( const basic_result<T, E>& res,
-                           failure<F> const& err );         // (21)
+                           err_t<F> const& err );         // (21)
 template< class T, class E, class U >
-constexpr bool operator!=( failure<E> const& err,
+constexpr bool operator!=( err_t<E> const& err,
                            const basic_result<T, F>& res ); // (22)
 template< class T, class E, class U >
 constexpr bool operator<( const basic_result<T, E>& res,
-                          failure<F> const& err );          // (23)
+                          err_t<F> const& err );          // (23)
 template< class T, class E, class U >
-constexpr bool operator<( failure<E> const& err,
+constexpr bool operator<( err_t<E> const& err,
                           const basic_result<T, F>& res );  // (24)
 template< class T, class E, class U >
 constexpr bool operator<=( const basic_result<T, E>& res,
-                          failure<F> const& err );          // (25)
+                          err_t<F> const& err );          // (25)
 template< class T, class E, class U >
-constexpr bool operator<=( failure<E> const& err,
+constexpr bool operator<=( err_t<E> const& err,
                           const basic_result<T, F>& res );  // (26)
 template< class T, class E, class U >
 constexpr bool operator>( const basic_result<T, E>& res,
-                          failure<F> const& err );          // (27)
+                          err_t<F> const& err );          // (27)
 template< class T, class E, class U >
-constexpr bool operator>( failure<E> const& err,
+constexpr bool operator>( err_t<E> const& err,
                           const basic_result<T, F>& res );  // (28)
 template< class T, class E, class U >
 constexpr bool operator>=( const basic_result<T, E>& res,
-                          failure<F> const& err );          // (29)
+                          err_t<F> const& err );          // (29)
 template< class T, class E, class U >
-constexpr bool operator>=( failure<E> const& err,
+constexpr bool operator>=( err_t<E> const& err,
                           const basic_result<T, F>& res );  // (30)
 
 // Compare a basic_result object with a T
@@ -140,32 +140,32 @@ constexpr bool operator>=( const T& value,
 
 Performs comparison operations on basic_result objects.
 
-1-6) Compares two basic_result objects, `lhs` and `rhs`. The contained values are compared (using the corresponding operator of `T` and `U` or `E` and `F`) only if the contents of `lhs` and `rhs` are either both success values or are both failure values.
+1-6) Compares two basic_result objects, `lhs` and `rhs`. The contained values are compared (using the corresponding operator of `T` and `U` or `E` and `F`) only if the contents of `lhs` and `rhs` are either both ok values or are both err values.
 
 Otherwise,
 
-- `lhs` is considered less than `rhs` if, and only if, `rhs` contains a success value and `lhs` contains failure value.
-- `lhs` is considered less than `rhs` if, and only if, `rhs` contains a failure value and `lhs` contains success value.
+- `lhs` is considered less than `rhs` if, and only if, `rhs` contains an ok value and `lhs` contains err value.
+- `lhs` is considered less than `rhs` if, and only if, `rhs` contains an err value and `lhs` contains ok value.
 
-7-18) Compares `res` with a `ok`. The values are compared (using the corresponding operator of `E` and `F`) only if `res` contains a success value.
+7-18) Compares `res` with an `ok`. The values are compared (using the corresponding operator of `E` and `F`) only if `res` contains an ok value.
 Otherwise, `res` is considered less than `ok`.
 
-If the corresponding comparison expression between `res.unwrap()` and success value is not well-formed, or if its result is not convertible to bool, the behavior is undefined.
+If the corresponding comparison expression between `res.unwrap()` and ok value is not well-formed, or if its result is not convertible to bool, the behavior is undefined.
 
-19-30) Compares `res` with a `err`. The values are compared (using the corresponding operator of `T` and `U`) only if `res` contains a success value.
+19-30) Compares `res` with an `err`. The values are compared (using the corresponding operator of `T` and `U`) only if `res` contains an ok value.
 Otherwise, `res` is considered greater than `err`.
 
-If the corresponding comparison expression between `res.unwrap()` and failure value is not well-formed, or if its result is not convertible to bool, the behavior is undefined.
+If the corresponding comparison expression between `res.unwrap()` and err value is not well-formed, or if its result is not convertible to bool, the behavior is undefined.
 
-31-42) Compares `res` with a `value`. Equivalent to (7-18) expression `res ~ success(value)` or `success(value) ~ res`.
+31-42) Compares `res` with a `value`. Equivalent to (7-18) expression `res ~ ok(value)` or `ok(value) ~ res`.
 
 **Parameters**
 
 `lhs`, `rhs`, `res`	- basic_result object to compare
 
-`ok` - a success object to compare
+`ok` - an ok object to compare
 
-`err` - a failure object to compare
+`err` - an err object to compare
 
 `value`	- value to compare to the contained value
 
@@ -264,30 +264,30 @@ If the corresponding comparison expression between `res.unwrap()` and failure va
 
 30. Returns `res.is_err() ? err.value >= res.unwrap_err() : true`.
 
-31. Returns `res == success(value)`.
+31. Returns `res == ok(value)`.
 
-32. Returns `success(value) == res`.
+32. Returns `ok(value) == res`.
 
-33. Returns `res != success(value)`.
+33. Returns `res != ok(value)`.
 
-34. Returns `success(value) != res`.
+34. Returns `ok(value) != res`.
 
-35. Returns `res < success(value)`.
+35. Returns `res < ok(value)`.
 
-36. Returns `success(value) < res`.
+36. Returns `ok(value) < res`.
 
-37. Returns `res <= success(value)`.
+37. Returns `res <= ok(value)`.
 
-38. Returns `success(value) <= res`.
+38. Returns `ok(value) <= res`.
 
-39. Returns `res > success(value)`.
+39. Returns `res > ok(value)`.
 
-40. Returns `success(value) > res`.
+40. Returns `ok(value) > res`.
 
-41. Returns `res >= success(value)`.
+41. Returns `res >= ok(value)`.
 
-42. Returns `success(value) >= res`.
+42. Returns `ok(value) >= res`.
 
 **Note**
 
-- `err.value`, `ok.value`: `value` is a private member of `success` or `failure` (actually, cannot access to it).
+- `err.value`, `ok.value`: `value` is a private member of `ok` or `err` (actually, cannot access to it).

--- a/docs/docs/result/intro.md
+++ b/docs/docs/result/intro.md
@@ -11,7 +11,7 @@ enum class mutability: bool {
 template < mutability Mut >
 inline constexpr bool is_mut_v = !static_cast<bool>(Mut);
 
-template <mutability, class /* success type */, class /* failure type */>
+template <mutability, class /* ok type */, class /* err type */>
 class basic_result;
 ```
 
@@ -34,27 +34,27 @@ The library provides two type synonyms of `basic_result` as follows:
 You should use `mut_result<T, E>` if you want to resubstitute,
 `result<T, E>` do not provides assignment operators or mutable accessors.
 
-## success/failure the in-place factory classes
+## ok/err the in-place factory classes
 
-`success_t` and `failure_t` are in-place factory classes for `basic_result`.
+`ok_t` and `err_t` are in-place factory classes for `basic_result`.
 
-If you want to initialize `result<T, E>` with successful value of `T`, initialize with `success_t<T>`.
+If you want to initialize `result<T, E>` with ok value of `T`, initialize with `ok_t<T>`.
 
 ```cpp
-result<int, std::string> res = success_t{42};
+result<int, std::string> res = ok_t{42};
 ```
 
-Similarly, if you want to initialize `result<T, E>` with unsuccessful value of `E`, initialize with `failure_t<E>`.
+Similarly, if you want to initialize `result<T, E>` with non-ok value of `E`, initialize with `err_t<E>`.
 
 ```cpp
-result<int, std::string> res = failure_t{"error"};
+result<int, std::string> res = err_t{"error"};
 ```
 
-However, using `success` and `failure` (factory methods) is recommended.
+However, using `ok` and `err` (factory methods) is recommended.
 
 ```cpp
-result<int, std::string> ok = success(42);
-result<int, std::string> ng = failure("error");
+result<int, std::string> ok = ok(42);
+result<int, std::string> ng = err("error");
 ```
 
 ## Result with reference types
@@ -70,7 +70,7 @@ using namespace mitama;
 
 int main() {
     int i = 1;
-    mut_result<int&, std::string&> res = success(i);
+    mut_result<int&, std::string&> res = ok(i);
     res.unwrap() = 2; // get reference to `i`, and assign `2`.
 
     assert(i == 2);
@@ -97,7 +97,7 @@ using namespace mitama;
 int main() {
   static_assert(!is_complete_type<incomplete_type>::value);
   [[maybe_unused]]
-  result<incomplete_type&, void> res = success<incomplete_type&>(get_incomplete_type()); // use incomplete_type& for result
+  result<incomplete_type&, void> res = ok_t<incomplete_type&>(get_incomplete_type()); // use incomplete_type& for result
 }
 
 struct incomplete_type {};

--- a/docs/docs/result/metafunctions.md
+++ b/docs/docs/result/metafunctions.md
@@ -22,13 +22,13 @@ template <class, class...>
 struct is_result_with : std::false_type {};
 
 template <class T, class E>
-struct is_result_with<result<T, E>, success<T>> : std::true_type {};
+struct is_result_with<result<T, E>, ok_t<T>> : std::true_type {};
 
 template <class T, class E>
-struct is_result_with<result<T, E>, failure<E>> : std::true_type {};
+struct is_result_with<result<T, E>, err_t<E>> : std::true_type {};
 
 template <class T, class E>
-struct is_result_with<result<T, E>, success<T>, failure<E>> : std::true_type {};
+struct is_result_with<result<T, E>, ok_t<T>, err_t<E>> : std::true_type {};
 
 template <class T, class... Requires>
 inline constexpr bool is_result_with_v = is_result_with<T, Requires...>::value;

--- a/docs/docs/result/special_members.md
+++ b/docs/docs/result/special_members.md
@@ -120,17 +120,17 @@ This constructor shall not participate in overload resolution unless
 
 If `is_trivially_move_constructible_v<T, U> && is_trivially_move_constructible_v<E, F>` is true, this constructor shall be a constexpr constructor.
 
-## non-explicit copy constructor from success [5/16]
+## non-explicit copy constructor from ok [5/16]
 
 ```cpp
 template<class U >
-basic_result::basic_result(success<U> const& ok)
+basic_result::basic_result(ok_t<U> const& ok)
 noexcept(see below)
 ```
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type `success<T>`.
+Initializes the contained variant as if in-place-initializing an object of type `ok_t<T>`.
 
 **Exceptions**
 
@@ -142,17 +142,17 @@ If `is_nothrow_move_constructible_v<T, U>` is true, this constructor shall be a 
 
 This constructor shall not participate in overload resolution unless `is_constructible_v<T, U> && is_convertible_v<U, T>` is true.
 
-## explicit copy constructor from success [6/16]
+## explicit copy constructor from ok [6/16]
 
 ```cpp
 template<class U >
-explicit basic_result::basic_result(success<U> const& ok)
+explicit basic_result::basic_result(ok_t<U> const& ok)
 noexcept(see below)
 ```
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type `success<T>`.
+Initializes the contained variant as if in-place-initializing an object of type `ok_t<T>`.
 
 **Exceptions**
 
@@ -164,17 +164,17 @@ If `is_nothrow_move_constructible_v<T, U>` is true, this constructor shall be a 
 
 This constructor shall not participate in overload resolution unless `is_constructible_v<T, U> && !is_convertible_v<U, T>` is true.
 
-## non-explicit move constructor from success [7/16]
+## non-explicit move constructor from ok [7/16]
 
 ```cpp
 template<class U >
-basic_result::basic_result(success<U>&& ok)
+basic_result::basic_result(ok_t<U>&& ok)
 noexcept(see below)
 ```
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type `success<T>`.
+Initializes the contained variant as if in-place-initializing an object of type `ok_t<T>`.
 
 **Exceptions**
 
@@ -186,17 +186,17 @@ If `is_nothrow_move_constructible_v<T, U>` is true, this constructor shall be a 
 
 This constructor shall not participate in overload resolution unless `is_constructible_v<T, U> && is_convertible_v<U, T>` is true.
 
-## explicit move constructor from success [8/16]
+## explicit move constructor from ok [8/16]
 
 ```cpp
 template<class U >
-explicit basic_result::basic_result(success<U>&& ok)
+explicit basic_result::basic_result(ok_t<U>&& ok)
 noexcept(see below)
 ```
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type `success<T>`.
+Initializes the contained variant as if in-place-initializing an object of type `ok_t<T>`.
 
 **Exceptions**
 
@@ -208,17 +208,17 @@ If `is_nothrow_move_constructible_v<T, U>` is true, this constructor shall be a 
 
 This constructor shall not participate in overload resolution unless `is_constructible_v<T, U> && !is_convertible_v<U, T>` is true.
 
-## non-explicit copy constructor from failure [9/16]
+## non-explicit copy constructor from err [9/16]
 
 ```cpp
 template <class F>
-basic_result::basic_result(failure<F> const& err)
+basic_result::basic_result(err_t<F> const& err)
 noexcept(see below)
 ```
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type `failure<E>`.
+Initializes the contained variant as if in-place-initializing an object of type `err_t<E>`.
 
 **Exceptions**
 
@@ -230,17 +230,17 @@ If `is_nothrow_move_constructible_v<E, F>` is true, this constructor shall be a 
 
 This constructor shall not participate in overload resolution unless `is_constructible_v<E, F> && is_convertible_v<F, E>` is true.
 
-## explicit copy constructor from failure [10/16]
+## explicit copy constructor from err [10/16]
 
 ```cpp
 template <class F>
-explicit basic_result::basic_result(failure<F> const& err)
+explicit basic_result::basic_result(err_t<F> const& err)
 noexcept(see below)
 ```
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type `failure<E>`.
+Initializes the contained variant as if in-place-initializing an object of type `err_t<E>`.
 
 **Exceptions**
 
@@ -252,17 +252,17 @@ If `is_nothrow_move_constructible_v<E, F>` is true, this constructor shall be a 
 
 This constructor shall not participate in overload resolution unless `is_constructible_v<E, F> && !is_convertible_v<F, E>` is true.
 
-## non-explicit move constructor from failure [11/16]
+## non-explicit move constructor from err [11/16]
 
 ```cpp
 template <class F>
-basic_result::basic_result(failure<F>&& err)
+basic_result::basic_result(err_t<F>&& err)
 noexcept(see below)
 ```
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type `failure<E>`.
+Initializes the contained variant as if in-place-initializing an object of type `err_t<E>`.
 
 **Exceptions**
 
@@ -274,17 +274,17 @@ If `is_nothrow_move_constructible_v<E, F>` is true, this constructor shall be a 
 
 This constructor shall not participate in overload resolution unless `is_constructible_v<E, F> && is_convertible_v<F, E>` is true.
 
-## explicit move constructor from failure [12/16]
+## explicit move constructor from err [12/16]
 
 ```cpp
 template <class F>
-explicit basic_result::basic_result(failure<F>&& err)
+explicit basic_result::basic_result(err_t<F>&& err)
 noexcept(see below)
 ```
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type `failure<E>&&`.
+Initializes the contained variant as if in-place-initializing an object of type `err_t<E>&&`.
 
 **Exceptions**
 
@@ -296,7 +296,7 @@ If `is_nothrow_move_constructible_v<E, F>` is true, this constructor shall be a 
 
 This constructor shall not participate in overload resolution unless `is_constructible_v<E, U> && !is_convertible_v<U, E>` is true.
 
-## emplace constructor for successful results [13/16]
+## emplace constructor for ok results [13/16]
 
 ```cpp
 template <class... Args>
@@ -306,7 +306,7 @@ noexcept(see below)
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type with expression `(success<T>(std::forward<Args>(args)...))`.
+Initializes the contained variant as if in-place-initializing an object of type with expression `(ok_t<T>(std::forward<Args>(args)...))`.
 
 **Exceptions**
 
@@ -319,10 +319,10 @@ If `is_nothrow_move_constructible_v<T, Args&&...>` is true, this constructor sha
 ```cpp
 using my_result = result<std::tuple<int, int>, std::string>;
 auto res = my_result( mitama::in_place_ok, 1, 1 );
-// same as `my_result(success(std::tuple{1,1}))`
+// same as `my_result(ok(std::tuple{1,1}))`
 ```
 
-## emplace constructor for unsuccessful results [14/16]
+## emplace constructor for non-ok results [14/16]
 
 ```cpp
 template <class... Args>
@@ -331,7 +331,7 @@ explicit basic_result::basic_result(in_place_err_t, Args&&... args)
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type with expression `(failure<E>(std::forward<Args>(args)...))`.
+Initializes the contained variant as if in-place-initializing an object of type with expression `(err_t<E>(std::forward<Args>(args)...))`.
 
 **Exceptions**
 
@@ -343,10 +343,10 @@ If `is_nothrow_move_constructible_v<E, Args&&...>` is true, this constructor sha
 
 ```cpp
 using my_result = result<int, std::string>;
-auto res = my_result( mitama::in_place_err, 'a', 5 ); // failure("aaaaa")
+auto res = my_result( mitama::in_place_err, 'a', 5 ); // err("aaaaa")
 ```
 
-## emplace constructor with initializer_list for successful results [15/16]
+## emplace constructor with initializer_list for ok results [15/16]
 
 ```cpp
 template <class U , class... Args>
@@ -357,7 +357,7 @@ explicit basic_result::basic_result(in_place_ok_t,
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type with expression `(success<T>(il, std::forward<Args>(args)...))`.
+Initializes the contained variant as if in-place-initializing an object of type with expression `(ok_t<T>(il, std::forward<Args>(args)...))`.
 
 **Exceptions**
 
@@ -367,10 +367,10 @@ Any exception thrown by the selected constructor of T.
 
 ```cpp
 using my_result = result<std::vector<int>, std::string>;
-auto res = my_result( in_place_ok, {1,2,3,4}, std::allocator<int>()); // success([1,2,3,4])
+auto res = my_result( in_place_ok, {1,2,3,4}, std::allocator<int>()); // ok([1,2,3,4])
 ```
 
-## emplace constructor with initializer_list for unsuccessful results [16/16]
+## emplace constructor with initializer_list for non-ok results [16/16]
 
 ```cpp
 template <class U , class... Args>
@@ -381,7 +381,7 @@ explicit basic_result::basic_result(in_place_ok_t ,
 
 **Effects**
 
-Initializes the contained variant as if in-place-initializing an object of type with expression `(failure<E>(il, std::forward<Args>(args)...))`.
+Initializes the contained variant as if in-place-initializing an object of type with expression `(err_t<E>(il, std::forward<Args>(args)...))`.
 
 **Exceptions**
 
@@ -391,7 +391,7 @@ Any exception thrown by the selected constructor of `E`.
 
 ```cpp
 using my_result = result<std::string, std::vector<int>>;
-auto res = my_result( in_place_err, {1,2,3,4}); // failure([1,2,3,4])
+auto res = my_result( in_place_err, {1,2,3,4}); // err([1,2,3,4])
 ```
 
 # Assignment operators
@@ -441,17 +441,17 @@ Any exception thrown by the selected constructor of `T` or `E`.
 
 This operator fails by static assertion unless self is mutable.
 
-## copy assignment operator for success [3/6]
+## copy assignment operator for ok [3/6]
 
 ```cpp
   template <class U,
             where<std::is_constructible<T, U>> = required>
-  constexpr basic_result& basic_result::operator=(success<U> const& _ok)
+  constexpr basic_result& basic_result::operator=(ok_t<U> const& _ok)
 ```
 
 **Effects**
 
-Destroy the contained value and replace it with the successful value `_ok`.
+Destroy the contained value and replace it with the ok value `_ok`.
 
 **Exceptions**
 
@@ -461,17 +461,17 @@ Any exception thrown by the selected constructor of `T`.
 
 This operator fails by static assertion unless self is mutable.
 
-## move assignment operator for success [4/6]
+## move assignment operator for ok [4/6]
 
 ```cpp
   template <class U,
             where<std::is_constructible<T, U>> = required>
-  constexpr basic_result& basic_result::operator=(success<U>&& _ok)
+  constexpr basic_result& basic_result::operator=(ok_t<U>&& _ok)
 ```
 
 **Effects**
 
-Destroy the contained value and replace it with the successful value `_ok`.
+Destroy the contained value and replace it with the ok value `_ok`.
 
 **Exceptions**
 
@@ -481,17 +481,17 @@ Any exception thrown by the selected constructor of `T`.
 
 This operator fails by static assertion unless self is mutable.
 
-## copy assignment operator for failure [5/6]
+## copy assignment operator for err [5/6]
 
 ```cpp
   template <class F,
             where<std::is_constructible<E, F>> = required>
-  constexpr basic_result& basic_result::operator=(failure<F> const& _err)
+  constexpr basic_result& basic_result::operator=(err_t<F> const& _err)
 ```
 
 **Effects**
 
-Destroy the contained value and replace it with the unsuccessful value `_err`.
+Destroy the contained value and replace it with the non-ok value `_err`.
 
 **Exceptions**
 
@@ -501,17 +501,17 @@ Any exception thrown by the selected constructor of `E`.
 
 This operator fails by static assertion unless self is mutable.
 
-## move assignment operator for failure [6/6]
+## move assignment operator for err [6/6]
 
 ```cpp
   template <class F,
             where<std::is_constructible<E, F>> = required>
-  constexpr basic_result& basic_result::operator=(failure<F>&& _err)
+  constexpr basic_result& basic_result::operator=(err_t<F>&& _err)
 ```
 
 **Effects**
 
-Destroy the contained value and replace it with the unsuccessful value `_err`.
+Destroy the contained value and replace it with the non-ok value `_err`.
 
 **Exceptions**
 

--- a/docs/docs/thiserror/thiserror.md
+++ b/docs/docs/thiserror/thiserror.md
@@ -25,11 +25,11 @@ The format string should be a string compliant with [**{fmt}**](https://github.c
 The second template argument onwards is a list of formattable arguments.
 
 `mitama::thiserror::error` inherits from `anyhow::error`, so it can be used together with anyhow.
-The factory function `anyhow::failure` is used to create a `shared_ptr` for `thiserror::error`.
+The factory function `anyhow::err` is used to create a `shared_ptr` for `thiserror::error`.
 
 ```cpp
 anyhow::result<int> data
-    = anyhow::failure<data_store_error::disconnect>();
+    = anyhow::err<data_store_error::disconnect>();
 ```
 
 Examples:
@@ -57,7 +57,7 @@ struct data_store_error : mitama::thiserror::derive_error {
 
 int main() {
   anyhow::result<int> data
-      = anyhow::failure<data_store_error::redaction>("invalid key");
+      = anyhow::err<data_store_error::redaction>("invalid key");
   auto res = data
       .with_context([] { return anyhow::anyhow("data store failed."s); });
 }

--- a/include/mitama/anyhow/error.hpp
+++ b/include/mitama/anyhow/error.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <mitama/mitamagic/format.hpp>
-#include <mitama/result/factory/failure.hpp>
+#include <mitama/result/factory/err.hpp>
 
 #include <fmt/core.h>
 #include <memory>
@@ -175,10 +175,10 @@ operator<<(
 
 template <class Err, class... Args>
 inline auto
-failure(Args&&... args) -> mitama::failure_t<std::shared_ptr<Err>>
+err(Args&&... args) -> mitama::err_t<std::shared_ptr<Err>>
   requires std::is_base_of_v<mitama::anyhow::error, Err>
 {
-  return mitama::failure(std::make_shared<Err>(std::forward<Args>(args)...));
+  return mitama::err(std::make_shared<Err>(std::forward<Args>(args)...));
 }
 
 } // namespace mitama::anyhow
@@ -190,7 +190,7 @@ struct fmt::formatter<std::shared_ptr<mitama::anyhow::error>>
 };
 
 #define MITAMA_BAIL(...) \
-  return ::mitama::failure(::mitama::anyhow::anyhow(__VA_ARGS__))
+  return ::mitama::err(::mitama::anyhow::anyhow(__VA_ARGS__))
 
 #define MITAMA_ENSURE(COND, ...) \
   do                             \

--- a/include/mitama/boolinators.hpp
+++ b/include/mitama/boolinators.hpp
@@ -46,43 +46,43 @@ and_maybe_from(bool b, F&& may) -> std::invoke_result_t<F&&>
 
 template <class T>
 inline constexpr result<T, void>
-as_ok(bool b, T&& ok)
+as_ok(bool b, T&& o)
 {
-  return b ? result<T, void>(success(std::forward<T>(ok))) : failure();
+  return b ? result<T, void>(ok(std::forward<T>(o))) : err();
 }
 
 template <class T, class E>
 inline constexpr result<T, E>
-as_result(bool b, T&& ok, E&& err)
+as_result(bool b, T&& o, E&& e)
 {
-  return b ? result<T, E>{ success(std::forward<T>(ok)) }
-           : result<T, E>{ failure(std::forward<E>(err)) };
+  return b ? result<T, E>{ ok(std::forward<T>(o)) }
+           : result<T, E>{ err(std::forward<E>(e)) };
 }
 
 template <class F, class G>
 inline constexpr result<std::invoke_result_t<F>, std::invoke_result_t<G&&>>
-as_result_from(bool b, F&& ok, G&& err)
+as_result_from(bool b, F&& o, G&& e)
 {
   using result_type =
       result<std::invoke_result_t<F>, std::invoke_result_t<G&&>>;
-  return b ? result_type{ success(std::invoke(std::forward<F>(ok))) }
-           : result_type{ failure(std::invoke(std::forward<G>(err))) };
+  return b ? result_type{ ok(std::invoke(std::forward<F>(o))) }
+           : result_type{ err(std::invoke(std::forward<G>(e))) };
 }
 
 template <class E>
 inline constexpr result<void, E>
-ok_or(bool b, E&& err)
+ok_or(bool b, E&& e)
 {
-  return b ? result<void, E>{ success() }
-           : result<void, E>{ failure(std::forward<E>(err)) };
+  return b ? result<void, E>{ ok() }
+           : result<void, E>{ err(std::forward<E>(e)) };
 }
 
 template <class G>
 inline constexpr result<void, std::invoke_result_t<G&&>>
-ok_or_else(bool b, G&& err)
+ok_or_else(bool b, G&& e)
 {
   using result_type = result<void, std::invoke_result_t<G>>;
-  return b ? result_type{ success() }
-           : result_type{ failure(std::invoke(std::forward<G>(err))) };
+  return b ? result_type{ ok() }
+           : result_type{ err(std::invoke(std::forward<G>(e))) };
 }
 } // namespace mitama

--- a/include/mitama/maybe/maybe.hpp
+++ b/include/mitama/maybe/maybe.hpp
@@ -6,8 +6,8 @@
 #include <mitama/panic.hpp>
 #include <mitama/result/detail/fwd.hpp>
 #include <mitama/result/detail/meta.hpp>
-#include <mitama/result/factory/failure.hpp>
-#include <mitama/result/factory/success.hpp>
+#include <mitama/result/factory/err.hpp>
+#include <mitama/result/factory/ok.hpp>
 
 #include <cassert>
 #include <functional>
@@ -91,8 +91,7 @@ public:
   constexpr basic_result<_, maybe<T>, E> transpose() const&
   {
     const auto* self = static_cast<const maybe<basic_result<_, T, E>>*>(this);
-    return self->is_nothing()
-               ? basic_result<_, maybe<T>, E>{ success_t{ nothing } }
+    return self->is_nothing() ? basic_result<_, maybe<T>, E>{ ok_t{ nothing } }
            : self->unwrap().is_ok()
                ? basic_result<_, maybe<T>, E>{ in_place_ok, std::in_place,
                                                self->unwrap().unwrap() }
@@ -665,46 +664,42 @@ public:
   constexpr auto ok_or(E&& err = {}) &
   {
     using ret_t = result<value_type, std::remove_reference_t<E>>;
-    return is_just()
-               ? ret_t{ success_t{ unwrap() } }
-               : ret_t{ failure_t{ std::forward<E>(std::forward<E>(err)) } };
+    return is_just() ? ret_t{ ok_t{ unwrap() } }
+                     : ret_t{ err_t{ std::forward<E>(std::forward<E>(err)) } };
   }
 
   template <class E = std::monostate>
   constexpr auto ok_or(E&& err = {}) const&
   {
     using ret_t = result<value_type, std::remove_reference_t<E>>;
-    return is_just()
-               ? ret_t{ success_t{ unwrap() } }
-               : ret_t{ failure_t{ std::forward<E>(std::forward<E>(err)) } };
+    return is_just() ? ret_t{ ok_t{ unwrap() } }
+                     : ret_t{ err_t{ std::forward<E>(std::forward<E>(err)) } };
   }
 
   template <class E = std::monostate>
   constexpr auto ok_or(E&& err = {}) &&
   {
     using ret_t = result<value_type, std::remove_reference_t<E>>;
-    return is_just()
-               ? ret_t{ success_t{ std::move(unwrap()) } }
-               : ret_t{ failure_t{ std::forward<E>(std::forward<E>(err)) } };
+    return is_just() ? ret_t{ ok_t{ std::move(unwrap()) } }
+                     : ret_t{ err_t{ std::forward<E>(std::forward<E>(err)) } };
   }
 
   template <class F>
     requires std::is_invocable_v<F&&>
   constexpr result<T, std::invoke_result_t<F&&>> ok_or_else(F&& err) const&
   {
-    return is_just()
-               ? result<T, std::invoke_result_t<F&&>>{ success_t{ unwrap() } }
-               : result<T, std::invoke_result_t<F&&>>{ failure_t{
-                     std::invoke(std::forward<F>(err)) } };
+    return is_just() ? result<T, std::invoke_result_t<F&&>>{ ok_t{ unwrap() } }
+                     : result<T, std::invoke_result_t<F&&>>{ err_t{
+                           std::invoke(std::forward<F>(err)) } };
   }
 
   template <class F>
     requires std::is_invocable_v<F&&>
   constexpr result<T, std::invoke_result_t<F&&>> ok_or_else(F&& err) &&
   {
-    return is_just() ? result<T, std::invoke_result_t<F&&>>{ success_t{
+    return is_just() ? result<T, std::invoke_result_t<F&&>>{ ok_t{
                            std::move(unwrap()) } }
-                     : result<T, std::invoke_result_t<F&&>>{ failure_t{
+                     : result<T, std::invoke_result_t<F&&>>{ err_t{
                            std::invoke(std::forward<F>(err)) } };
   }
 

--- a/include/mitama/result/detail/fwd.hpp
+++ b/include/mitama/result/detail/fwd.hpp
@@ -34,7 +34,7 @@ template <class T>
 using void_to_monostate_t =
     std::conditional_t<std::is_void_v<T>, std::monostate, T>;
 
-template <mutability, class /* success type */, class /* failure type */>
+template <mutability, class /* ok type */, class /* err type */>
 class basic_result;
 
 /// alias template for immutable result
@@ -48,14 +48,14 @@ using mut_result = basic_result<
     mutability::mut, void_to_monostate_t<T>, void_to_monostate_t<E>>;
 
 template <class = std::monostate, class...>
-class success_t;
+class ok_t;
 template <class T>
-success_t(T&&) -> success_t<T>;
+ok_t(T&&) -> ok_t<T>;
 
 template <class = std::monostate, class...>
-class failure_t;
+class err_t;
 template <class E>
-failure_t(E&&) -> failure_t<E>;
+err_t(E&&) -> err_t<E>;
 
 class in_place_ok_t
 {

--- a/include/mitama/result/detail/result_impl.hpp
+++ b/include/mitama/result/detail/result_impl.hpp
@@ -35,7 +35,7 @@ public:
   ///
   /// @note
   ///   Consumes the self argument then,
-  ///   if success, returns the contained value,
+  ///   if ok, returns the contained value,
   ///   otherwise; if Err, returns the default value for that type.
   constexpr T unwrap_or_default() const
   {
@@ -72,8 +72,8 @@ public:
   ///
   /// @note
   ///   Consumes the self argument then,
-  ///   if success, returns the contained value,
-  ///   otherwise; if failure, returns the default value for that type.
+  ///   if ok, returns the contained value,
+  ///   otherwise; if err, returns the default value for that type.
   constexpr maybe<basic_result<_mutability, T, E>> transpose() const&
   {
     if (static_cast<const basic_result<_mutability, maybe<T>, E>*>(this)->is_ok(
@@ -166,7 +166,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the success arm of the basic_result via
+  ///   additionally coercing the ok arm of the basic_result via
   ///   `operator*`.
   constexpr auto indirect_ok() & -> indirect_ok_result
   {
@@ -195,7 +195,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the failure arm of the basic_result via
+  ///   additionally coercing the err arm of the basic_result via
   ///   `operator*`.
   constexpr auto indirect_err() & -> indirect_err_result
   {
@@ -226,7 +226,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the success and failure arm of the basic_result
+  ///   additionally coercing the ok and err arm of the basic_result
   ///   via `operator*`.
   constexpr auto indirect() & -> indirect_result
   {
@@ -256,7 +256,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the success arm of the basic_result via
+  ///   additionally coercing the ok arm of the basic_result via
   ///   `operator*`.
   constexpr auto indirect_ok() const& -> const_indirect_ok_result
   {
@@ -286,7 +286,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the failure arm of the basic_result via
+  ///   additionally coercing the err arm of the basic_result via
   ///   `operator*`.
   constexpr auto indirect_err() const& -> const_indirect_err_result
   {
@@ -317,7 +317,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the success and failure arm of the basic_result
+  ///   additionally coercing the ok and err arm of the basic_result
   ///   via `operator*`.
   constexpr auto indirect() const& -> const_indirect_result
   {
@@ -347,7 +347,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the success arm of the basic_result via
+  ///   additionally coercing the ok arm of the basic_result via
   ///   `operator*`.
   ///
   /// @warning
@@ -381,7 +381,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the failure arm of the basic_result via
+  ///   additionally coercing the err arm of the basic_result via
   ///   `operator*`.
   ///
   /// @warning
@@ -417,7 +417,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the success and failure arm of the basic_result
+  ///   additionally coercing the ok and err arm of the basic_result
   ///   via `operator*`.
   ///
   /// @warning
@@ -478,7 +478,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the success arm of the basic_result via
+  ///   additionally coercing the ok arm of the basic_result via
   ///   `operator*`.
   constexpr auto indirect_ok() & -> indirect_ok_result
   {
@@ -510,7 +510,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the success arm of the basic_result via
+  ///   additionally coercing the ok arm of the basic_result via
   ///   `operator*`.
   constexpr auto indirect_ok() const& -> const_indirect_ok_result
   {
@@ -542,7 +542,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the success arm of the basic_result via
+  ///   additionally coercing the ok arm of the basic_result via
   ///   `operator*`.
   ///
   /// @warning
@@ -602,7 +602,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the failure arm of the basic_result via
+  ///   additionally coercing the err arm of the basic_result via
   ///   `operator*`.
   constexpr auto indirect_err() & -> indirect_err_result
   {
@@ -634,7 +634,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the failure arm of the basic_result via
+  ///   additionally coercing the err arm of the basic_result via
   ///   `operator*`.
   constexpr auto indirect_err() const& -> const_indirect_err_result
   {
@@ -666,7 +666,7 @@ public:
   /// @note
   ///   Leaves the original basic_result in-place,
   ///   creating a new one with a reference to the original one,
-  ///   additionally coercing the failure arm of the basic_result via
+  ///   additionally coercing the err arm of the basic_result via
   ///   `operator*`.
   ///
   /// @warning
@@ -711,8 +711,8 @@ class map_apply_friend_injector<basic_result<_mu, T, E>>
 {
 public:
   ///   Maps a basic_result<(Ts...), E> to basic_result<U, E> by applying a
-  ///   function to a contained tuple elements if holds success values,
-  ///   otherwise; returns the failure value of self.
+  ///   function to a contained tuple elements if holds ok values,
+  ///   otherwise; returns the err value of self.
   ///
   /// @note
   ///   This function can be used to compose the results of two functions.
@@ -730,7 +730,7 @@ public:
         )),
         E>;
     return static_cast<const basic_result<_mu, T, E>*>(this)->is_ok()
-               ? static_cast<result_type>(success_t{ std::apply(
+               ? static_cast<result_type>(ok_t{ std::apply(
                      std::forward<O>(op),
                      std::tuple_cat(
                          static_cast<const basic_result<_mu, T, E>*>(this)
@@ -738,7 +738,7 @@ public:
                          std::forward_as_tuple(std::forward<Args>(args))...
                      )
                  ) })
-               : static_cast<result_type>(failure_t{
+               : static_cast<result_type>(err_t{
                      static_cast<const basic_result<_mu, T, E>*>(this)
                          ->unwrap_err() });
   }
@@ -757,8 +757,8 @@ class map_err_apply_friend_injector<basic_result<_mu, T, E>>
 {
 public:
   ///   Maps a basic_result<T, (Ts...)> to basic_result<T, F> by applying a
-  ///   function to a contained tuple elements if holds failure values,
-  ///   otherwise; returns the success value of self.
+  ///   function to a contained tuple elements if holds err values,
+  ///   otherwise; returns the ok value of self.
   ///
   /// @note
   ///   This function can be used to compose the results of two functions.
@@ -775,9 +775,9 @@ public:
             )
         ))>;
     return static_cast<basic_result<_mu, T, E>*>(this)->is_ok()
-               ? static_cast<result_type>(success_t{
+               ? static_cast<result_type>(ok_t{
                      static_cast<basic_result<_mu, T, E>*>(this)->unwrap() })
-               : static_cast<result_type>(failure_t{ std::apply(
+               : static_cast<result_type>(err_t{ std::apply(
                      std::forward<O>(op),
                      std::tuple_cat(
                          static_cast<basic_result<_mu, T, E>*>(this)
@@ -800,10 +800,10 @@ public:
             )
         ))>;
     return static_cast<const basic_result<_mu, T, E>*>(this)->is_ok()
-               ? static_cast<result_type>(success_t{
+               ? static_cast<result_type>(ok_t{
                      static_cast<const basic_result<_mu, T, E>*>(this)->unwrap(
                      ) })
-               : static_cast<result_type>(failure_t{ std::apply(
+               : static_cast<result_type>(err_t{ std::apply(
                      std::forward<O>(op),
                      std::tuple_cat(
                          static_cast<const basic_result<_mu, T, E>*>(this)
@@ -826,9 +826,9 @@ public:
             )
         ))>;
     return static_cast<basic_result<_mu, T, E>*>(this)->is_ok()
-               ? static_cast<result_type>(success_t{
+               ? static_cast<result_type>(ok_t{
                      static_cast<basic_result<_mu, T, E>*>(this)->unwrap() })
-               : static_cast<result_type>(failure_t{ std::apply(
+               : static_cast<result_type>(err_t{ std::apply(
                      std::forward<O>(op),
                      std::tuple_cat(
                          std::move(static_cast<basic_result<_mu, T, E>*>(this)
@@ -860,7 +860,7 @@ public:
                 std::forward_as_tuple(std::declval<Args&&>()...)
             )
         )),
-        failure_t<E>>
+        err_t<E>>
   constexpr auto and_then_apply(O&& op, Args&&... args) &
   {
     using result_type = decltype(std::apply(
@@ -879,7 +879,7 @@ public:
                          std::forward_as_tuple(std::forward<Args>(args))...
                      )
                  ))
-               : static_cast<result_type>(failure(
+               : static_cast<result_type>(err(
                      static_cast<basic_result<_mu, T, E>*>(this)->unwrap_err()
                  ));
   }
@@ -893,7 +893,7 @@ public:
                 std::forward_as_tuple(std::declval<Args&&>()...)
             )
         )),
-        failure_t<E>>
+        err_t<E>>
   constexpr auto and_then_apply(O&& op, Args&&... args) const&
   {
     using result_type = decltype(std::apply(
@@ -914,8 +914,8 @@ public:
                      )
                  ))
                : static_cast<result_type>(
-                     failure(static_cast<const basic_result<_mu, T, E>*>(this)
-                                 ->unwrap_err())
+                     err(static_cast<const basic_result<_mu, T, E>*>(this)
+                             ->unwrap_err())
                  );
   }
 
@@ -928,7 +928,7 @@ public:
                 std::forward_as_tuple(std::declval<Args&&>()...)
             )
         )),
-        failure_t<E>>
+        err_t<E>>
   constexpr auto and_then_apply(O&& op, Args&&... args) &&
   {
     using result_type = decltype(std::apply(
@@ -948,7 +948,7 @@ public:
                          std::forward_as_tuple(std::forward<Args>(args)...)
                      )
                  ))
-               : static_cast<result_type>(failure(std::move(
+               : static_cast<result_type>(err(std::move(
                      static_cast<basic_result<_mu, T, E>*>(this)->unwrap_err()
                  )));
   }
@@ -975,7 +975,7 @@ public:
                 std::forward_as_tuple(std::declval<Args&&>()...)
             )
         )),
-        success_t<T>>
+        ok_t<T>>
   constexpr auto or_else_apply(O&& op, Args&&... args) const&
   {
     using result_type = decltype(std::apply(
@@ -995,7 +995,7 @@ public:
                          std::forward_as_tuple(std::forward<Args>(args))...
                      )
                  ))
-               : static_cast<result_type>(success(
+               : static_cast<result_type>(ok(
                      static_cast<const basic_result<_mu, T, E>*>(this)->unwrap()
                  ));
   }

--- a/include/mitama/result/factory/ok.hpp
+++ b/include/mitama/result/factory/ok.hpp
@@ -11,32 +11,32 @@
 
 namespace mitama
 {
-/// class success_t:
-/// The main use of this class is to propagate successful results to the
+/// class ok_t:
+/// The main use of this class is to propagate ok results to the
 /// constructor of the result class.
 template <class T>
-class [[nodiscard]] success_t<T>
+class [[nodiscard]] ok_t<T>
 {
   template <class, class...>
-  friend class success_t;
+  friend class ok_t;
   T x;
 
   template <class U>
-  using not_self = std::negation<std::is_same<success_t, U>>;
+  using not_self = std::negation<std::is_same<ok_t, U>>;
 
 public:
-  using ok_type = T;
+  using value_type = T;
 
   template <class U = T>
     requires std::is_same_v<std::monostate, U>
-  constexpr success_t(std::nullptr_t = nullptr)
+  constexpr ok_t(std::nullptr_t = nullptr)
   { /* whatever */
   }
 
   template <class U>
     requires not_self<std::decay_t<U>>::value
              && std::is_constructible_v<T, U> && std::is_convertible_v<U, T>
-  constexpr success_t(U&& u) noexcept(std::is_nothrow_constructible_v<T, U>)
+  constexpr ok_t(U&& u) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::forward<U>(u))
   {
   }
@@ -44,8 +44,7 @@ public:
   template <class U>
     requires not_self<std::decay_t<U>>::value
              && std::is_constructible_v<T, U> && (!std::is_convertible_v<U, T>)
-  explicit constexpr success_t(U&& u
-  ) noexcept(std::is_nothrow_constructible_v<T, U>)
+  explicit constexpr ok_t(U&& u) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::forward<U>(u))
   {
   }
@@ -53,7 +52,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, const U&>
             && std::is_convertible_v<const U&, T>
-  constexpr success_t(const success_t<U>& t
+  constexpr ok_t(const ok_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(t.get())
   {
@@ -62,7 +61,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, const U&>
             && (!std::is_convertible_v<const U&, T>)
-  explicit constexpr success_t(const success_t<U>& t
+  explicit constexpr ok_t(const ok_t<U>& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(t.get())
   {
@@ -71,8 +70,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>)
             && std::is_constructible_v<T, U&&> && std::is_convertible_v<U&&, T>
-  constexpr success_t(success_t<U>&& t
-  ) noexcept(std::is_nothrow_constructible_v<T, U>)
+  constexpr ok_t(ok_t<U>&& t) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::move(t.get()))
   {
   }
@@ -80,7 +78,7 @@ public:
   template <typename U>
     requires(!std::is_same_v<T, U>) && std::is_constructible_v<T, U&&>
             && (!std::is_convertible_v<U &&, T>)
-  explicit constexpr success_t(success_t<U>&& t
+  explicit constexpr ok_t(ok_t<U>&& t
   ) noexcept(std::is_nothrow_constructible_v<T, U>)
       : x(std::move(t.get()))
   {
@@ -88,7 +86,7 @@ public:
 
   template <class... Args>
     requires std::is_constructible_v<T, Args...>
-  explicit constexpr success_t(
+  explicit constexpr ok_t(
       std::in_place_t, Args&&... args
   ) noexcept(std::is_nothrow_constructible_v<T, Args...>)
       : x(std::forward<Args>(args)...)
@@ -104,13 +102,13 @@ public:
 
   template <class T_>
     requires meta::is_comparable_with<T, T_>::value
-  constexpr bool operator==(const success_t<T_>& rhs) const
+  constexpr bool operator==(const ok_t<T_>& rhs) const
   {
     return this->x == rhs.x;
   }
 
   template <class E_>
-  constexpr bool operator==(const failure_t<E_>&) const
+  constexpr bool operator==(const err_t<E_>&) const
   {
     return false;
   }
@@ -124,13 +122,13 @@ public:
 
   template <class T_>
     requires meta::is_comparable_with<T, T_>::value
-  constexpr bool operator!=(const success_t<T_>& rhs) const
+  constexpr bool operator!=(const ok_t<T_>& rhs) const
   {
     return !(this->x == rhs.x);
   }
 
   template <class E_>
-  constexpr bool operator!=(const failure_t<E_>&) const
+  constexpr bool operator!=(const err_t<E_>&) const
   {
     return true;
   }
@@ -144,13 +142,13 @@ public:
 
   template <class T_>
     requires meta::is_less_comparable_with<T, T_>::value
-  constexpr bool operator<(const success_t<T_>& rhs) const
+  constexpr bool operator<(const ok_t<T_>& rhs) const
   {
     return this->x < rhs.x;
   }
 
   template <class E_>
-  constexpr bool operator<(const failure_t<E_>&) const
+  constexpr bool operator<(const err_t<E_>&) const
   {
     return false;
   }
@@ -167,13 +165,13 @@ public:
   template <class T_>
     requires meta::is_comparable_with<T, T_>::value
              && meta::is_less_comparable_with<T, T_>::value
-  constexpr bool operator<=(const success_t<T_>& rhs) const
+  constexpr bool operator<=(const ok_t<T_>& rhs) const
   {
     return (this->x == rhs.x) || (this->x < rhs.x);
   }
 
   template <class E_>
-  constexpr bool operator<=(const failure_t<E_>&) const
+  constexpr bool operator<=(const err_t<E_>&) const
   {
     return false;
   }
@@ -187,13 +185,13 @@ public:
 
   template <class T_>
     requires meta::is_less_comparable_with<T_, T>::value
-  constexpr bool operator>(const success_t<T_>& rhs) const
+  constexpr bool operator>(const ok_t<T_>& rhs) const
   {
     return rhs < *this;
   }
 
   template <class E_>
-  constexpr bool operator>(const failure_t<E_>&) const
+  constexpr bool operator>(const err_t<E_>&) const
   {
     return true;
   }
@@ -209,13 +207,13 @@ public:
 
   template <class T_>
     requires meta::is_comparable_with<T, T_>::value
-  constexpr bool operator>=(const success_t<T_>& rhs) const
+  constexpr bool operator>=(const ok_t<T_>& rhs) const
   {
     return rhs <= *this;
   }
 
   template <class E_>
-  constexpr bool operator>=(const failure_t<E_>&) const
+  constexpr bool operator>=(const err_t<E_>&) const
   {
     return true;
   }
@@ -235,35 +233,35 @@ public:
 };
 
 template <class T>
-class [[nodiscard]] success_t<T&>
+class [[nodiscard]] ok_t<T&>
 {
   template <class, class...>
-  friend class success_t;
+  friend class ok_t;
   std::reference_wrapper<T> x;
 
   template <class U>
-  using not_self = std::negation<std::is_same<success_t, U>>;
+  using not_self = std::negation<std::is_same<ok_t, U>>;
 
 public:
-  using ok_type = T&;
+  using value_type = T&;
 
-  success_t() = delete;
-  explicit constexpr success_t(T& ok) : x(ok) {}
-  explicit constexpr success_t(std::in_place_t, T& ok) : x(ok) {}
+  ok_t() = delete;
+  explicit constexpr ok_t(T& ok) : x(ok) {}
+  explicit constexpr ok_t(std::in_place_t, T& ok) : x(ok) {}
 
   template <class U>
-  explicit constexpr success_t(U& value) : x(value)
+  explicit constexpr ok_t(U& value) : x(value)
   {
   }
   template <class U>
-  explicit constexpr success_t(std::in_place_t, U& value) : x(value)
+  explicit constexpr ok_t(std::in_place_t, U& value) : x(value)
   {
   }
 
-  explicit constexpr success_t(success_t&&) = default;
-  explicit constexpr success_t(const success_t&) = default;
-  constexpr success_t& operator=(success_t&&) = default;
-  constexpr success_t& operator=(const success_t&) = default;
+  explicit constexpr ok_t(ok_t&&) = default;
+  explicit constexpr ok_t(const ok_t&) = default;
+  constexpr ok_t& operator=(ok_t&&) = default;
+  constexpr ok_t& operator=(const ok_t&) = default;
 
   template <mutability _mut, class T_, class E_>
     requires meta::is_comparable_with<T, T_>::value
@@ -274,13 +272,13 @@ public:
 
   template <class T_>
     requires meta::is_comparable_with<T, T_>::value
-  constexpr bool operator==(const success_t<T_>& rhs) const
+  constexpr bool operator==(const ok_t<T_>& rhs) const
   {
     return this->x == rhs.x;
   }
 
   template <class E_>
-  constexpr bool operator==(const failure_t<E_>&) const
+  constexpr bool operator==(const err_t<E_>&) const
   {
     return false;
   }
@@ -294,13 +292,13 @@ public:
 
   template <class T_>
     requires meta::is_comparable_with<T, T_>::value
-  constexpr bool operator!=(const success_t<T_>& rhs) const
+  constexpr bool operator!=(const ok_t<T_>& rhs) const
   {
     return !(this->x == rhs.x);
   }
 
   template <class E_>
-  constexpr bool operator!=(const failure_t<E_>&) const
+  constexpr bool operator!=(const err_t<E_>&) const
   {
     return true;
   }
@@ -314,13 +312,13 @@ public:
 
   template <class T_>
     requires meta::is_less_comparable_with<T, T_>::value
-  constexpr bool operator<(const success_t<T_>& rhs) const
+  constexpr bool operator<(const ok_t<T_>& rhs) const
   {
     return this->x < rhs.x;
   }
 
   template <class E_>
-  constexpr bool operator<(const failure_t<E_>&) const
+  constexpr bool operator<(const err_t<E_>&) const
   {
     return false;
   }
@@ -337,13 +335,13 @@ public:
   template <class T_>
     requires meta::is_comparable_with<T, T_>::value
              && meta::is_less_comparable_with<T, T_>::value
-  constexpr bool operator<=(const success_t<T_>& rhs) const
+  constexpr bool operator<=(const ok_t<T_>& rhs) const
   {
     return (this->x == rhs.x) || (this->x < rhs.x);
   }
 
   template <class E_>
-  constexpr bool operator<=(const failure_t<E_>&) const
+  constexpr bool operator<=(const err_t<E_>&) const
   {
     return false;
   }
@@ -357,13 +355,13 @@ public:
 
   template <class T_>
     requires meta::is_less_comparable_with<T_, T>::value
-  constexpr bool operator>(const success_t<T_>& rhs) const
+  constexpr bool operator>(const ok_t<T_>& rhs) const
   {
     return rhs < *this;
   }
 
   template <class E_>
-  constexpr bool operator>(const failure_t<E_>&) const
+  constexpr bool operator>(const err_t<E_>&) const
   {
     return true;
   }
@@ -379,13 +377,13 @@ public:
 
   template <class T_>
     requires meta::is_comparable_with<T, T_>::value
-  constexpr bool operator>=(const success_t<T_>& rhs) const
+  constexpr bool operator>=(const ok_t<T_>& rhs) const
   {
     return rhs <= *this;
   }
 
   template <class E_>
-  constexpr bool operator>=(const failure_t<E_>&) const
+  constexpr bool operator>=(const err_t<E_>&) const
   {
     return true;
   }
@@ -405,14 +403,12 @@ public:
 };
 
 template <class T, class... Args>
-class [[nodiscard]] success_t<_result_detail::forward_mode<T>, Args...>
+class [[nodiscard]] ok_t<_result_detail::forward_mode<T>, Args...>
 {
   std::tuple<Args...> args;
 
 public:
-  constexpr explicit success_t(Args... args) : args(std::forward<Args>(args)...)
-  {
-  }
+  constexpr explicit ok_t(Args... args) : args(std::forward<Args>(args)...) {}
 
   constexpr auto operator()() &&
   {
@@ -426,25 +422,25 @@ public:
 
 template <class Target = void, class... Types>
 inline constexpr auto
-success(Types&&... v)
+ok(Types&&... v)
 {
   if constexpr (!std::is_void_v<Target>)
   {
     if constexpr (sizeof...(Types) < 2)
-      return success_t<Target>{ std::forward<Types>(v)... };
+      return ok_t<Target>{ std::forward<Types>(v)... };
     else
-      return success_t<_result_detail::forward_mode<Target>, Types&&...>{
+      return ok_t<_result_detail::forward_mode<Target>, Types&&...>{
         std::forward<Types>(v)...
       };
   }
   else
   {
     if constexpr (sizeof...(Types) == 0)
-      return success_t<>{};
+      return ok_t<>{};
     else if constexpr (sizeof...(Types) == 1)
-      return success_t<Types...>{ std::forward<Types>(v)... };
+      return ok_t<Types...>{ std::forward<Types>(v)... };
     else
-      return success_t<_result_detail::forward_mode<>, Types&&...>{
+      return ok_t<_result_detail::forward_mode<>, Types&&...>{
         std::forward<Types>(v)...
       };
   }
@@ -462,14 +458,14 @@ success(Types&&... v)
 ///   found by ADL.
 template <class T>
 inline std::ostream&
-operator<<(std::ostream& os, const success_t<T>& ok)
+operator<<(std::ostream& os, const ok_t<T>& ok)
 {
-  return os << fmt::format("success({})", quote_str(ok.get()));
+  return os << fmt::format("ok({})", quote_str(ok.get()));
 }
 
 } // namespace mitama
 
 template <class T>
-struct fmt::formatter<mitama::success_t<T>> : ostream_formatter
+struct fmt::formatter<mitama::ok_t<T>> : ostream_formatter
 {
 };

--- a/include/mitama/result/result_io.hpp
+++ b/include/mitama/result/result_io.hpp
@@ -22,8 +22,8 @@ std::ostream&
 operator<<(std::ostream& os, const basic_result<_, T, E>& res)
 {
   return res.is_ok()
-             ? os << fmt::format("success({})", quote_str(res.unwrap()))
-             : os << fmt::format("failure({})", quote_str(res.unwrap_err()));
+             ? os << fmt::format("ok({})", quote_str(res.unwrap()))
+             : os << fmt::format("err({})", quote_str(res.unwrap_err()));
 }
 
 } // namespace mitama

--- a/test/maybe_tests.cpp
+++ b/test/maybe_tests.cpp
@@ -172,22 +172,22 @@ TEST_CASE("map_or_else()", "[maybe][map_or_else]")
 TEST_CASE("ok_or()", "[maybe][ok_or]")
 {
   constexpr maybe x = just("foo"sv);
-  static_assert(x.ok_or(0) == success("foo"sv));
+  static_assert(x.ok_or(0) == ok("foo"sv));
 
   constexpr maybe<std::string_view> y = nothing;
-  static_assert(y.ok_or(0) == failure(0));
+  static_assert(y.ok_or(0) == err(0));
 
-  static_assert(y.ok_or() == failure<>());
-  static_assert(y.ok_or<int>() == failure(int{}));
+  static_assert(y.ok_or() == err<>());
+  static_assert(y.ok_or<int>() == err(int{}));
 }
 
 TEST_CASE("ok_or_else()", "[maybe][ok_or_else]")
 {
   constexpr maybe x = just("foo"sv);
-  static_assert(x.ok_or_else([] { return 0; }) == success("foo"sv));
+  static_assert(x.ok_or_else([] { return 0; }) == ok("foo"sv));
 
   constexpr maybe<std::string_view> y = nothing;
-  static_assert(y.ok_or_else([] { return 0; }) == failure(0));
+  static_assert(y.ok_or_else([] { return 0; }) == err(0));
 }
 
 TEST_CASE("conj()", "[maybe][conj]")
@@ -417,8 +417,8 @@ TEST_CASE("replace()", "[maybe][replace]")
 
 TEST_CASE("transpose()", "[maybe][transpose]")
 {
-  constexpr result<maybe<int>, std::string_view> x = success(just(5));
-  constexpr maybe<result<int, std::string_view>> y = just(success(5));
+  constexpr result<maybe<int>, std::string_view> x = ok(just(5));
+  constexpr maybe<result<int, std::string_view>> y = just(ok(5));
   static_assert(x == y.transpose());
 }
 

--- a/test/special_member_tests.hpp
+++ b/test/special_member_tests.hpp
@@ -4,546 +4,525 @@
 #include <type_traits>
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<true, true, true, true>>>
+    std::is_copy_constructible_v<ok_t<TestClass<true, true, true, true>>>
     == true
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<true, true, true, true>>>
+    std::is_copy_assignable_v<ok_t<TestClass<true, true, true, true>>> == true
+);
+static_assert(
+    std::is_move_constructible_v<ok_t<TestClass<true, true, true, true>>>
     == true
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<true, true, true, true>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<success<TestClass<true, true, true, true>>>
-    == true
+    std::is_move_assignable_v<ok_t<TestClass<true, true, true, true>>> == true
 );
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<true, true, true, false>>>
+    std::is_copy_constructible_v<ok_t<TestClass<true, true, true, false>>>
     == true
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<true, true, true, false>>>
+    std::is_copy_assignable_v<ok_t<TestClass<true, true, true, false>>> == true
+);
+static_assert(
+    std::is_move_constructible_v<ok_t<TestClass<true, true, true, false>>>
     == true
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<true, true, true, false>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<success<TestClass<true, true, true, false>>>
-    == true
+    std::is_move_assignable_v<ok_t<TestClass<true, true, true, false>>> == true
 );
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<true, false, true, true>>>
+    std::is_copy_constructible_v<ok_t<TestClass<true, false, true, true>>>
     == true
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<true, false, true, true>>>
+    std::is_copy_assignable_v<ok_t<TestClass<true, false, true, true>>> == false
+);
+static_assert(
+    std::is_move_constructible_v<ok_t<TestClass<true, false, true, true>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<ok_t<TestClass<true, false, true, true>>> == true
+);
+
+static_assert(
+    std::is_copy_constructible_v<ok_t<TestClass<true, false, true, false>>>
+    == true
+);
+static_assert(
+    std::is_copy_assignable_v<ok_t<TestClass<true, false, true, false>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<true, false, true, true>>>
+    std::is_move_constructible_v<ok_t<TestClass<true, false, true, false>>>
     == true
 );
 static_assert(
-    std::is_move_assignable_v<success<TestClass<true, false, true, true>>>
-    == true
-);
-
-static_assert(
-    std::is_copy_constructible_v<success<TestClass<true, false, true, false>>>
-    == true
-);
-static_assert(
-    std::is_copy_assignable_v<success<TestClass<true, false, true, false>>>
-    == false
-);
-static_assert(
-    std::is_move_constructible_v<success<TestClass<true, false, true, false>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<success<TestClass<true, false, true, false>>>
+    std::is_move_assignable_v<ok_t<TestClass<true, false, true, false>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<true, true, false, true>>>
+    std::is_copy_constructible_v<ok_t<TestClass<true, true, false, true>>>
     == true
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<true, true, false, true>>>
+    std::is_copy_assignable_v<ok_t<TestClass<true, true, false, true>>> == true
+);
+static_assert(
+    std::is_move_constructible_v<ok_t<TestClass<true, true, false, true>>>
     == true
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<true, true, false, true>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<success<TestClass<true, true, false, true>>>
-    == true
+    std::is_move_assignable_v<ok_t<TestClass<true, true, false, true>>> == true
 );
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<true, true, false, false>>>
+    std::is_copy_constructible_v<ok_t<TestClass<true, true, false, false>>>
     == true
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<true, true, false, false>>>
+    std::is_copy_assignable_v<ok_t<TestClass<true, true, false, false>>> == true
+);
+static_assert(
+    std::is_move_constructible_v<ok_t<TestClass<true, true, false, false>>>
     == true
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<true, true, false, false>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<success<TestClass<true, true, false, false>>>
-    == true
+    std::is_move_assignable_v<ok_t<TestClass<true, true, false, false>>> == true
 );
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<true, false, false, true>>>
+    std::is_copy_constructible_v<ok_t<TestClass<true, false, false, true>>>
     == true
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<true, false, false, true>>>
+    std::is_copy_assignable_v<ok_t<TestClass<true, false, false, true>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<true, false, false, true>>>
+    std::is_move_constructible_v<ok_t<TestClass<true, false, false, true>>>
     == true
 );
 static_assert(
-    std::is_move_assignable_v<success<TestClass<true, false, false, true>>>
+    std::is_move_assignable_v<ok_t<TestClass<true, false, false, true>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<true, false, false, false>>>
+    std::is_copy_constructible_v<ok_t<TestClass<true, false, false, false>>>
     == true
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<true, false, false, false>>>
+    std::is_copy_assignable_v<ok_t<TestClass<true, false, false, false>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<true, false, false, false>>>
+    std::is_move_constructible_v<ok_t<TestClass<true, false, false, false>>>
     == true
 );
 static_assert(
-    std::is_move_assignable_v<success<TestClass<true, false, false, false>>>
+    std::is_move_assignable_v<ok_t<TestClass<true, false, false, false>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<false, true, true, true>>>
+    std::is_copy_constructible_v<ok_t<TestClass<false, true, true, true>>>
     == false
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<false, true, true, true>>>
-    == false
+    std::is_copy_assignable_v<ok_t<TestClass<false, true, true, true>>> == false
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<false, true, true, true>>>
+    std::is_move_constructible_v<ok_t<TestClass<false, true, true, true>>>
     == true
 );
 static_assert(
-    std::is_move_assignable_v<success<TestClass<false, true, true, true>>>
-    == true
+    std::is_move_assignable_v<ok_t<TestClass<false, true, true, true>>> == true
 );
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<false, true, true, false>>>
+    std::is_copy_constructible_v<ok_t<TestClass<false, true, true, false>>>
     == false
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<false, true, true, false>>>
+    std::is_copy_assignable_v<ok_t<TestClass<false, true, true, false>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<false, true, true, false>>>
+    std::is_move_constructible_v<ok_t<TestClass<false, true, true, false>>>
     == true
 );
 static_assert(
-    std::is_move_assignable_v<success<TestClass<false, true, true, false>>>
-    == false
-);
-
-static_assert(
-    std::is_copy_constructible_v<success<TestClass<false, false, true, true>>>
-    == false
-);
-static_assert(
-    std::is_copy_assignable_v<success<TestClass<false, false, true, true>>>
-    == false
-);
-static_assert(
-    std::is_move_constructible_v<success<TestClass<false, false, true, true>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<success<TestClass<false, false, true, true>>>
-    == true
-);
-
-static_assert(
-    std::is_copy_constructible_v<success<TestClass<false, false, true, false>>>
-    == false
-);
-static_assert(
-    std::is_copy_assignable_v<success<TestClass<false, false, true, false>>>
-    == false
-);
-static_assert(
-    std::is_move_constructible_v<success<TestClass<false, false, true, false>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<success<TestClass<false, false, true, false>>>
+    std::is_move_assignable_v<ok_t<TestClass<false, true, true, false>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<false, true, false, true>>>
+    std::is_copy_constructible_v<ok_t<TestClass<false, false, true, true>>>
     == false
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<false, true, false, true>>>
+    std::is_copy_assignable_v<ok_t<TestClass<false, false, true, true>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<false, true, false, true>>>
+    std::is_move_constructible_v<ok_t<TestClass<false, false, true, true>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<ok_t<TestClass<false, false, true, true>>> == true
+);
+
+static_assert(
+    std::is_copy_constructible_v<ok_t<TestClass<false, false, true, false>>>
     == false
 );
 static_assert(
-    std::is_move_assignable_v<success<TestClass<false, true, false, true>>>
+    std::is_copy_assignable_v<ok_t<TestClass<false, false, true, false>>>
+    == false
+);
+static_assert(
+    std::is_move_constructible_v<ok_t<TestClass<false, false, true, false>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<ok_t<TestClass<false, false, true, false>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<false, true, false, false>>>
+    std::is_copy_constructible_v<ok_t<TestClass<false, true, false, true>>>
     == false
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<false, true, false, false>>>
+    std::is_copy_assignable_v<ok_t<TestClass<false, true, false, true>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<false, true, false, false>>>
+    std::is_move_constructible_v<ok_t<TestClass<false, true, false, true>>>
     == false
 );
 static_assert(
-    std::is_move_assignable_v<success<TestClass<false, true, false, false>>>
-    == false
-);
-
-static_assert(
-    std::is_copy_constructible_v<success<TestClass<false, false, false, true>>>
-    == false
-);
-static_assert(
-    std::is_copy_assignable_v<success<TestClass<false, false, false, true>>>
-    == false
-);
-static_assert(
-    std::is_move_constructible_v<success<TestClass<false, false, false, true>>>
-    == false
-);
-static_assert(
-    std::is_move_assignable_v<success<TestClass<false, false, false, true>>>
+    std::is_move_assignable_v<ok_t<TestClass<false, true, false, true>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<success<TestClass<false, false, false, false>>>
+    std::is_copy_constructible_v<ok_t<TestClass<false, true, false, false>>>
     == false
 );
 static_assert(
-    std::is_copy_assignable_v<success<TestClass<false, false, false, false>>>
+    std::is_copy_assignable_v<ok_t<TestClass<false, true, false, false>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<success<TestClass<false, false, false, false>>>
+    std::is_move_constructible_v<ok_t<TestClass<false, true, false, false>>>
     == false
 );
 static_assert(
-    std::is_move_assignable_v<success<TestClass<false, false, false, false>>>
-    == false
-);
-
-static_assert(
-    std::is_copy_constructible_v<failure<TestClass<true, true, true, true>>>
-    == true
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<true, true, true, true>>>
-    == true
-);
-static_assert(
-    std::is_move_constructible_v<failure<TestClass<true, true, true, true>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<failure<TestClass<true, true, true, true>>>
-    == true
-);
-
-static_assert(
-    std::is_copy_constructible_v<failure<TestClass<true, true, true, false>>>
-    == true
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<true, true, true, false>>>
-    == true
-);
-static_assert(
-    std::is_move_constructible_v<failure<TestClass<true, true, true, false>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<failure<TestClass<true, true, true, false>>>
-    == true
-);
-
-static_assert(
-    std::is_copy_constructible_v<failure<TestClass<true, false, true, true>>>
-    == true
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<true, false, true, true>>>
-    == false
-);
-static_assert(
-    std::is_move_constructible_v<failure<TestClass<true, false, true, true>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<failure<TestClass<true, false, true, true>>>
-    == true
-);
-
-static_assert(
-    std::is_copy_constructible_v<failure<TestClass<true, false, true, false>>>
-    == true
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<true, false, true, false>>>
-    == false
-);
-static_assert(
-    std::is_move_constructible_v<failure<TestClass<true, false, true, false>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<failure<TestClass<true, false, true, false>>>
+    std::is_move_assignable_v<ok_t<TestClass<false, true, false, false>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<failure<TestClass<true, true, false, true>>>
-    == true
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<true, true, false, true>>>
-    == true
-);
-static_assert(
-    std::is_move_constructible_v<failure<TestClass<true, true, false, true>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<failure<TestClass<true, true, false, true>>>
-    == true
-);
-
-static_assert(
-    std::is_copy_constructible_v<failure<TestClass<true, true, false, false>>>
-    == true
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<true, true, false, false>>>
-    == true
-);
-static_assert(
-    std::is_move_constructible_v<failure<TestClass<true, true, false, false>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<failure<TestClass<true, true, false, false>>>
-    == true
-);
-
-static_assert(
-    std::is_copy_constructible_v<failure<TestClass<true, false, false, true>>>
-    == true
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<true, false, false, true>>>
+    std::is_copy_constructible_v<ok_t<TestClass<false, false, false, true>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<failure<TestClass<true, false, false, true>>>
-    == true
+    std::is_copy_assignable_v<ok_t<TestClass<false, false, false, true>>>
+    == false
 );
 static_assert(
-    std::is_move_assignable_v<failure<TestClass<true, false, false, true>>>
+    std::is_move_constructible_v<ok_t<TestClass<false, false, false, true>>>
+    == false
+);
+static_assert(
+    std::is_move_assignable_v<ok_t<TestClass<false, false, false, true>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<failure<TestClass<true, false, false, false>>>
-    == true
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<true, false, false, false>>>
+    std::is_copy_constructible_v<ok_t<TestClass<false, false, false, false>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<failure<TestClass<true, false, false, false>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<failure<TestClass<true, false, false, false>>>
-    == false
-);
-
-static_assert(
-    std::is_copy_constructible_v<failure<TestClass<false, true, true, true>>>
+    std::is_copy_assignable_v<ok_t<TestClass<false, false, false, false>>>
     == false
 );
 static_assert(
-    std::is_copy_assignable_v<failure<TestClass<false, true, true, true>>>
+    std::is_move_constructible_v<ok_t<TestClass<false, false, false, false>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<failure<TestClass<false, true, true, true>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<failure<TestClass<false, true, true, true>>>
-    == true
-);
-
-static_assert(
-    std::is_copy_constructible_v<failure<TestClass<false, true, true, false>>>
-    == false
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<false, true, true, false>>>
-    == false
-);
-static_assert(
-    std::is_move_constructible_v<failure<TestClass<false, true, true, false>>>
-    == true
-);
-static_assert(
-    std::is_move_assignable_v<failure<TestClass<false, true, true, false>>>
+    std::is_move_assignable_v<ok_t<TestClass<false, false, false, false>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<failure<TestClass<false, false, true, true>>>
-    == false
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<false, false, true, true>>>
-    == false
-);
-static_assert(
-    std::is_move_constructible_v<failure<TestClass<false, false, true, true>>>
+    std::is_copy_constructible_v<err_t<TestClass<true, true, true, true>>>
     == true
 );
 static_assert(
-    std::is_move_assignable_v<failure<TestClass<false, false, true, true>>>
+    std::is_copy_assignable_v<err_t<TestClass<true, true, true, true>>> == true
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<true, true, true, true>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<true, true, true, true>>> == true
+);
+
+static_assert(
+    std::is_copy_constructible_v<err_t<TestClass<true, true, true, false>>>
+    == true
+);
+static_assert(
+    std::is_copy_assignable_v<err_t<TestClass<true, true, true, false>>> == true
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<true, true, true, false>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<true, true, true, false>>> == true
+);
+
+static_assert(
+    std::is_copy_constructible_v<err_t<TestClass<true, false, true, true>>>
+    == true
+);
+static_assert(
+    std::is_copy_assignable_v<err_t<TestClass<true, false, true, true>>>
+    == false
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<true, false, true, true>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<true, false, true, true>>> == true
+);
+
+static_assert(
+    std::is_copy_constructible_v<err_t<TestClass<true, false, true, false>>>
+    == true
+);
+static_assert(
+    std::is_copy_assignable_v<err_t<TestClass<true, false, true, false>>>
+    == false
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<true, false, true, false>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<true, false, true, false>>>
+    == false
+);
+
+static_assert(
+    std::is_copy_constructible_v<err_t<TestClass<true, true, false, true>>>
+    == true
+);
+static_assert(
+    std::is_copy_assignable_v<err_t<TestClass<true, true, false, true>>> == true
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<true, true, false, true>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<true, true, false, true>>> == true
+);
+
+static_assert(
+    std::is_copy_constructible_v<err_t<TestClass<true, true, false, false>>>
+    == true
+);
+static_assert(
+    std::is_copy_assignable_v<err_t<TestClass<true, true, false, false>>>
+    == true
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<true, true, false, false>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<true, true, false, false>>>
     == true
 );
 
 static_assert(
-    std::is_copy_constructible_v<failure<TestClass<false, false, true, false>>>
-    == false
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<false, false, true, false>>>
-    == false
-);
-static_assert(
-    std::is_move_constructible_v<failure<TestClass<false, false, true, false>>>
+    std::is_copy_constructible_v<err_t<TestClass<true, false, false, true>>>
     == true
 );
 static_assert(
-    std::is_move_assignable_v<failure<TestClass<false, false, true, false>>>
+    std::is_copy_assignable_v<err_t<TestClass<true, false, false, true>>>
+    == false
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<true, false, false, true>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<true, false, false, true>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<failure<TestClass<false, true, false, true>>>
+    std::is_copy_constructible_v<err_t<TestClass<true, false, false, false>>>
+    == true
+);
+static_assert(
+    std::is_copy_assignable_v<err_t<TestClass<true, false, false, false>>>
     == false
 );
 static_assert(
-    std::is_copy_assignable_v<failure<TestClass<false, true, false, true>>>
-    == false
+    std::is_move_constructible_v<err_t<TestClass<true, false, false, false>>>
+    == true
 );
 static_assert(
-    std::is_move_constructible_v<failure<TestClass<false, true, false, true>>>
-    == false
-);
-static_assert(
-    std::is_move_assignable_v<failure<TestClass<false, true, false, true>>>
-    == false
-);
-
-static_assert(
-    std::is_copy_constructible_v<failure<TestClass<false, true, false, false>>>
-    == false
-);
-static_assert(
-    std::is_copy_assignable_v<failure<TestClass<false, true, false, false>>>
-    == false
-);
-static_assert(
-    std::is_move_constructible_v<failure<TestClass<false, true, false, false>>>
-    == false
-);
-static_assert(
-    std::is_move_assignable_v<failure<TestClass<false, true, false, false>>>
+    std::is_move_assignable_v<err_t<TestClass<true, false, false, false>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<failure<TestClass<false, false, false, true>>>
+    std::is_copy_constructible_v<err_t<TestClass<false, true, true, true>>>
     == false
 );
 static_assert(
-    std::is_copy_assignable_v<failure<TestClass<false, false, false, true>>>
+    std::is_copy_assignable_v<err_t<TestClass<false, true, true, true>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<failure<TestClass<false, false, false, true>>>
+    std::is_move_constructible_v<err_t<TestClass<false, true, true, true>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<false, true, true, true>>> == true
+);
+
+static_assert(
+    std::is_copy_constructible_v<err_t<TestClass<false, true, true, false>>>
     == false
 );
 static_assert(
-    std::is_move_assignable_v<failure<TestClass<false, false, false, true>>>
+    std::is_copy_assignable_v<err_t<TestClass<false, true, true, false>>>
+    == false
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<false, true, true, false>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<false, true, true, false>>>
     == false
 );
 
 static_assert(
-    std::is_copy_constructible_v<failure<TestClass<false, false, false, false>>>
+    std::is_copy_constructible_v<err_t<TestClass<false, false, true, true>>>
     == false
 );
 static_assert(
-    std::is_copy_assignable_v<failure<TestClass<false, false, false, false>>>
+    std::is_copy_assignable_v<err_t<TestClass<false, false, true, true>>>
     == false
 );
 static_assert(
-    std::is_move_constructible_v<failure<TestClass<false, false, false, false>>>
+    std::is_move_constructible_v<err_t<TestClass<false, false, true, true>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<false, false, true, true>>>
+    == true
+);
+
+static_assert(
+    std::is_copy_constructible_v<err_t<TestClass<false, false, true, false>>>
     == false
 );
 static_assert(
-    std::is_move_assignable_v<failure<TestClass<false, false, false, false>>>
+    std::is_copy_assignable_v<err_t<TestClass<false, false, true, false>>>
+    == false
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<false, false, true, false>>>
+    == true
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<false, false, true, false>>>
+    == false
+);
+
+static_assert(
+    std::is_copy_constructible_v<err_t<TestClass<false, true, false, true>>>
+    == false
+);
+static_assert(
+    std::is_copy_assignable_v<err_t<TestClass<false, true, false, true>>>
+    == false
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<false, true, false, true>>>
+    == false
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<false, true, false, true>>>
+    == false
+);
+
+static_assert(
+    std::is_copy_constructible_v<err_t<TestClass<false, true, false, false>>>
+    == false
+);
+static_assert(
+    std::is_copy_assignable_v<err_t<TestClass<false, true, false, false>>>
+    == false
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<false, true, false, false>>>
+    == false
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<false, true, false, false>>>
+    == false
+);
+
+static_assert(
+    std::is_copy_constructible_v<err_t<TestClass<false, false, false, true>>>
+    == false
+);
+static_assert(
+    std::is_copy_assignable_v<err_t<TestClass<false, false, false, true>>>
+    == false
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<false, false, false, true>>>
+    == false
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<false, false, false, true>>>
+    == false
+);
+
+static_assert(
+    std::is_copy_constructible_v<err_t<TestClass<false, false, false, false>>>
+    == false
+);
+static_assert(
+    std::is_copy_assignable_v<err_t<TestClass<false, false, false, false>>>
+    == false
+);
+static_assert(
+    std::is_move_constructible_v<err_t<TestClass<false, false, false, false>>>
+    == false
+);
+static_assert(
+    std::is_move_assignable_v<err_t<TestClass<false, false, false, false>>>
     == false
 );
 


### PR DESCRIPTION
Since result uses ok & err for methods, such as is_ok(), using ok & err instead of success & failure helps reduce divergence in the codebase. Also, they are shorter for users.