### PR TITLE
Propagate locations correctly

### DIFF
--- a/include/mitama/maybe/maybe.hpp
+++ b/include/mitama/maybe/maybe.hpp
@@ -11,6 +11,7 @@
 
 #include <cassert>
 #include <functional>
+#include <source_location>
 #include <string_view>
 #include <tuple>
 #include <type_traits>
@@ -350,24 +351,28 @@ public:
     return !is_just();
   }
 
-  constexpr value_type& unwrap() &
+  constexpr value_type&
+  unwrap(const std::source_location& loc = std::source_location::current()) &
   {
     if (is_nothing())
-      PANIC("called `maybe::unwrap()` on a `nothing` value");
+      PANIC("called `maybe::unwrap()` on a `nothing` value", loc);
     return std::get<just_t<T>>(storage_).get();
   }
 
-  constexpr std::add_const_t<std::remove_reference_t<T>>& unwrap() const&
+  constexpr std::add_const_t<std::remove_reference_t<T>>& unwrap(
+      const std::source_location& loc = std::source_location::current()
+  ) const&
   {
     if (is_nothing())
-      PANIC("called `maybe::unwrap()` on a `nothing` value");
+      PANIC("called `maybe::unwrap()` on a `nothing` value", loc);
     return std::get<just_t<T>>(storage_).get();
   }
 
-  constexpr value_type unwrap() &&
+  constexpr value_type
+  unwrap(const std::source_location& loc = std::source_location::current()) &&
   {
     if (is_nothing())
-      PANIC("called `maybe::unwrap()` on a `nothing` value");
+      PANIC("called `maybe::unwrap()` on a `nothing` value", loc);
     return std::move(std::get<just_t<T>>(storage_).get());
   }
 
@@ -598,7 +603,10 @@ public:
                      : std::invoke(std::forward<D>(def));
   }
 
-  constexpr value_type& expect(std::string_view msg) &
+  constexpr value_type& expect(
+      std::string_view msg,
+      const std::source_location& loc = std::source_location::current()
+  ) &
   {
     if (is_just())
     {
@@ -606,11 +614,14 @@ public:
     }
     else
     {
-      PANIC("{}", msg);
+      PANIC("{}", msg, loc);
     }
   }
 
-  constexpr const value_type& expect(std::string_view msg) const&
+  constexpr const value_type& expect(
+      std::string_view msg,
+      const std::source_location& loc = std::source_location::current()
+  ) const&
   {
     if (is_just())
     {
@@ -618,11 +629,14 @@ public:
     }
     else
     {
-      PANIC("{}", msg);
+      PANIC("{}", msg, loc);
     }
   }
 
-  constexpr value_type&& expect(std::string_view msg) &&
+  constexpr value_type&& expect(
+      std::string_view msg,
+      const std::source_location& loc = std::source_location::current()
+  ) &&
   {
     if (is_just())
     {
@@ -630,7 +644,7 @@ public:
     }
     else
     {
-      PANIC("{}", msg);
+      PANIC("{}", msg, loc);
     }
   }
 

--- a/include/mitama/panic.hpp
+++ b/include/mitama/panic.hpp
@@ -3,8 +3,75 @@
 #include <mitama/mitamagic/format.hpp>
 
 #include <fmt/core.h>
+#include <fmt/std.h>
+#include <source_location>
 #include <stdexcept>
 #include <utility>
+
+// FIXME: When we drop fmt < 100200 support, remove this entire block.
+#if FMT_VERSION < 100200
+
+/*
+ * The following std::source_location formatter implementation is derived from
+ * the {fmt} library:
+ * https://github.com/fmtlib/fmt
+ *
+ * Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * --- Optional exception to the license ---
+ *
+ * As an exception, if, as a result of your compiling your source code, portions
+ * of this Software are embedded into a machine-executable object form of such
+ * source code, you may redistribute such embedded portions in such object form
+ * without including the above copyright and permission notices.
+ *
+ * All other code in this file is separately licensed.
+ */
+
+template <>
+struct formatter<std::source_location>
+{
+  template <typename ParseContext>
+  FMT_CONSTEXPR auto parse(ParseContext& ctx)
+  {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(const std::source_location& loc, FormatContext& ctx) const
+      -> decltype(ctx.out())
+  {
+    auto out = ctx.out();
+    out = detail::write(out, loc.file_name());
+    out = detail::write(out, ':');
+    out = detail::write<char>(out, loc.line());
+    out = detail::write(out, ':');
+    out = detail::write<char>(out, loc.column());
+    out = detail::write(out, ": ");
+    out = detail::write(out, loc.function_name());
+    return out;
+  }
+};
+#endif
 
 namespace mitama
 {
@@ -14,21 +81,41 @@ class runtime_panic : public std::runtime_error
 public:
   template <class... Args>
   explicit runtime_panic(
-      const char* file, const int line, fmt::format_string<Args...> f,
+      const std::source_location& loc, fmt::format_string<Args...> f,
       Args&&... args
   ) noexcept
       : std::runtime_error(fmt::format(
-            "runtime panicked at '{}', {}:{}",
-            fmt::format(f, std::forward<Args>(args)...), file, line
+            "runtime panicked at '{}', {}",
+            fmt::format(f, std::forward<Args>(args)...), loc
         ))
   {
   }
 };
 
+namespace detail
+{
+
+  template <class... Args>
+  struct runtime_panic_proxy : runtime_panic
+  {
+    explicit runtime_panic_proxy(
+        fmt::format_string<Args...> f, Args&&... args,
+        const std::source_location& loc = std::source_location::current()
+    ) noexcept
+        : runtime_panic(loc, f, std::forward<Args>(args)...)
+    {
+    }
+  };
+  template <class... Args>
+  runtime_panic_proxy(fmt::format_string<Args...>, Args&&...)
+      -> runtime_panic_proxy<Args...>;
+
+} // namespace detail
+
 } // namespace mitama
 
-#define PANIC(...)                  \
-  throw ::mitama::runtime_panic     \
-  {                                 \
-    __FILE__, __LINE__, __VA_ARGS__ \
+#define PANIC(...)                            \
+  throw ::mitama::detail::runtime_panic_proxy \
+  {                                           \
+    __VA_ARGS__                               \
   }

--- a/include/mitama/result/result.hpp
+++ b/include/mitama/result/result.hpp
@@ -13,6 +13,7 @@
 #include <fmt/std.h>
 #include <functional>
 #include <memory>
+#include <source_location>
 #include <string_view>
 #include <tuple>
 #include <type_traits>
@@ -1359,7 +1360,9 @@ public:
   /// @panics
   ///   Panics if the value is an failure, with a panic message provided by the
   ///   failure's value.
-  constexpr force_add_const_t<T>& unwrap() const&
+  constexpr force_add_const_t<T>& unwrap(
+      const std::source_location& loc = std::source_location::current()
+  ) const&
   {
     if constexpr (fmt::is_formattable<E>::value)
     {
@@ -1371,7 +1374,7 @@ public:
       {
         PANIC(
             "called `basic_result::unwrap()` on a value: `{}`",
-            std::get<failure_t<E>>(storage_)
+            std::get<failure_t<E>>(storage_), loc
         );
       }
     }
@@ -1383,7 +1386,7 @@ public:
       }
       else
       {
-        PANIC("called `basic_result::unwrap()` on a value `failure(?)`");
+        PANIC("called `basic_result::unwrap()` on a value `failure(?)`", loc);
       }
     }
   }
@@ -1395,7 +1398,7 @@ public:
   ///   Panics if the value is an failure, with a panic message provided by the
   ///   failure's value.
   constexpr std::conditional_t<is_mut_v<_mutability>, T&, force_add_const_t<T>&>
-  unwrap() &
+  unwrap(const std::source_location& loc = std::source_location::current()) &
   {
     if constexpr (fmt::is_formattable<E>::value)
     {
@@ -1407,7 +1410,7 @@ public:
       {
         PANIC(
             "called `basic_result::unwrap()` on a value: `{}`",
-            std::get<failure_t<E>>(storage_)
+            std::get<failure_t<E>>(storage_), loc
         );
       }
     }
@@ -1419,7 +1422,7 @@ public:
       }
       else
       {
-        PANIC("called `basic_result::unwrap()` on a value `failure_t(?)`");
+        PANIC("called `basic_result::unwrap()` on a value `failure_t(?)`", loc);
       }
     }
   }
@@ -1430,7 +1433,9 @@ public:
   /// @panics
   ///   Panics if the value is an success, with a panic message provided by the
   ///   success's value.
-  constexpr force_add_const_t<E>& unwrap_err() const&
+  constexpr force_add_const_t<E>& unwrap_err(
+      const std::source_location& loc = std::source_location::current()
+  ) const&
   {
     if constexpr (fmt::is_formattable<T>::value)
     {
@@ -1442,7 +1447,7 @@ public:
       {
         PANIC(
             "called `basic_result::unwrap_err()` on a value: `{}`",
-            std::get<success_t<T>>(storage_)
+            std::get<success_t<T>>(storage_), loc
         );
       }
     }
@@ -1454,7 +1459,9 @@ public:
       }
       else
       {
-        PANIC("called `basic_result::unwrap_err()` on a value `success_t(?)`");
+        PANIC(
+            "called `basic_result::unwrap_err()` on a value `success_t(?)`", loc
+        );
       }
     }
   }
@@ -1466,7 +1473,9 @@ public:
   ///   Panics if the value is an success, with a panic message provided by the
   ///   success's value.
   constexpr std::conditional_t<is_mut_v<_mutability>, E&, force_add_const_t<E>&>
-  unwrap_err() &
+  unwrap_err(
+      const std::source_location& loc = std::source_location::current()
+  ) &
   {
     if constexpr (fmt::is_formattable<T>::value)
     {
@@ -1478,7 +1487,7 @@ public:
       {
         PANIC(
             "called `basic_result::unwrap_err()` on a value: `{}`",
-            std::get<success_t<T>>(storage_)
+            std::get<success_t<T>>(storage_), loc
         );
       }
     }
@@ -1490,7 +1499,10 @@ public:
       }
       else
       {
-        PANIC("called `basic_result::unwrap_err()` on a value `success_t(?)`)");
+        PANIC(
+            "called `basic_result::unwrap_err()` on a value `success_t(?)`)",
+            loc
+        );
       }
     }
   }
@@ -1501,11 +1513,14 @@ public:
   /// @panics
   ///   Panics if the value is an failure, with a panic message including the
   ///   passed message, and the content of the failure.
-  constexpr force_add_const_t<T>& expect(std::string_view msg) const&
+  constexpr force_add_const_t<T>& expect(
+      std::string_view msg,
+      const std::source_location& loc = std::source_location::current()
+  ) const&
   {
     if (is_err())
     {
-      PANIC("{}: {}", msg, unwrap_err());
+      PANIC("{}: {}", msg, unwrap_err(), loc);
     }
     else
     {
@@ -1519,11 +1534,14 @@ public:
   /// @panics
   ///   Panics if the value is an failure, with a panic message including the
   ///   passed message, and the content of the failure.
-  constexpr decltype(auto) expect(std::string_view msg) &
+  constexpr decltype(auto) expect(
+      std::string_view msg,
+      const std::source_location& loc = std::source_location::current()
+  ) &
   {
     if (is_err())
     {
-      PANIC("{}: {}", msg, unwrap_err());
+      PANIC("{}: {}", msg, unwrap_err(), loc);
     }
     else
     {
@@ -1537,11 +1555,14 @@ public:
   /// @panics
   ///   Panics if the value is an success, with a panic message including the
   ///   passed message, and the content of the success.
-  constexpr force_add_const_t<E>& expect_err(std::string_view msg) const&
+  constexpr force_add_const_t<E>& expect_err(
+      std::string_view msg,
+      const std::source_location& loc = std::source_location::current()
+  ) const&
   {
     if (is_ok())
     {
-      PANIC("{}: {}", msg, unwrap_err());
+      PANIC("{}: {}", msg, unwrap_err(), loc);
     }
     else
     {
@@ -1555,11 +1576,14 @@ public:
   /// @panics
   ///   Panics if the value is an success, with a panic message including the
   ///   passed message, and the content of the success.
-  constexpr decltype(auto) expect_err(std::string_view msg) &
+  constexpr decltype(auto) expect_err(
+      std::string_view msg,
+      const std::source_location& loc = std::source_location::current()
+  ) &
   {
     if (is_ok())
     {
-      PANIC("{}: {}", msg, unwrap_err());
+      PANIC("{}: {}", msg, unwrap_err(), loc);
     }
     else
     {


### PR DESCRIPTION
The current implementation shows the location information of the actual
implementation location instead of its callsite when an internal panic
happens.

This patch fixes this problem by propagating location information from
the callsite all the way down to runtime_panic.